### PR TITLE
feat: add database v2 migration

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -1,4 +1,4 @@
-from .base import DB_PATH, init_db
+from .base import DB_PATH, init_db, migrate_if_needed
 from .subjects import (
     get_levels,
     get_level_id_by_name,
@@ -36,7 +36,7 @@ from .materials import (
 )
 
 __all__ = [
-    'DB_PATH', 'init_db',
+    'DB_PATH', 'init_db', 'migrate_if_needed',
     'get_levels', 'get_level_id_by_name', 'get_term_id_by_name',
     'insert_level', 'insert_term', 'insert_subject',
     'get_terms_by_level', 'get_subjects_by_level_and_term', 'get_subject_id_by_name',

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -2,12 +2,90 @@ import os
 import aiosqlite
 
 DB_PATH = "database/archive.db"
+DB_VERSION = 2
 
 
 async def init_db() -> None:
-    """Ensure database folder exists and execute schema/init.sql once."""
+    """Ensure database directory exists and migrate database to latest version."""
     os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    await migrate_if_needed()
+
+
+async def migrate_if_needed() -> None:
+    """Upgrade database schema to the latest version if needed."""
     async with aiosqlite.connect(DB_PATH) as db:
-        with open("database/init.sql", "r", encoding="utf-8") as f:
-            await db.executescript(f.read())
+        cur = await db.execute("PRAGMA user_version")
+        row = await cur.fetchone()
+        user_version = row[0] if row else 0
+
+        if user_version == 0:
+            # Fresh database initialization
+            with open("database/init.sql", "r", encoding="utf-8") as f:
+                await db.executescript(f.read())
+            await db.execute(f"PRAGMA user_version={DB_VERSION}")
+            await db.commit()
+            return
+
+        if user_version >= DB_VERSION:
+            return
+
+        # Sequential migrations
+        if user_version < 2:
+            await db.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS admins (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tg_user_id INTEGER NOT NULL UNIQUE,
+                    username TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS groups (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tg_chat_id INTEGER NOT NULL UNIQUE,
+                    title TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS topics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    group_id INTEGER NOT NULL,
+                    tg_topic_id INTEGER NOT NULL,
+                    title TEXT,
+                    FOREIGN KEY (group_id) REFERENCES groups(id)
+                );
+
+                ALTER TABLE subjects
+                    ADD COLUMN sections_mode TEXT NOT NULL DEFAULT 'theory_only'
+                        CHECK(sections_mode IN (
+                            'theory_only',
+                            'theory_discussion',
+                            'theory_discussion_lab'
+                        ));
+
+                ALTER TABLE materials ADD COLUMN tg_storage_chat_id INTEGER;
+                ALTER TABLE materials ADD COLUMN tg_storage_msg_id INTEGER;
+                ALTER TABLE materials ADD COLUMN source_chat_id INTEGER;
+                ALTER TABLE materials ADD COLUMN source_topic_id INTEGER;
+                ALTER TABLE materials ADD COLUMN source_message_id INTEGER;
+                ALTER TABLE materials ADD COLUMN created_by_admin_id INTEGER;
+
+                CREATE TABLE IF NOT EXISTS ingestions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    material_id INTEGER,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (material_id) REFERENCES materials(id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_materials_core
+                    ON materials(subject_id, section, year_id, category);
+                CREATE INDEX IF NOT EXISTS idx_materials_storage
+                    ON materials(tg_storage_chat_id, tg_storage_msg_id);
+                CREATE INDEX IF NOT EXISTS idx_topics_chat
+                    ON topics(group_id, tg_topic_id);
+                CREATE INDEX IF NOT EXISTS idx_ingestions_status
+                    ON ingestions(status, created_at);
+                """
+            )
+
+        await db.execute(f"PRAGMA user_version={DB_VERSION}")
         await db.commit()

--- a/database/init.sql
+++ b/database/init.sql
@@ -27,6 +27,13 @@ CREATE TABLE IF NOT EXISTS subjects (
     name TEXT NOT NULL,
     level_id INTEGER NOT NULL,
     term_id INTEGER NOT NULL,
+    sections_mode TEXT NOT NULL DEFAULT 'theory_only' CHECK(
+        sections_mode IN (
+            'theory_only',
+            'theory_discussion',
+            'theory_discussion_lab'
+        )
+    ),
     FOREIGN KEY (level_id) REFERENCES levels(id),
     FOREIGN KEY (term_id) REFERENCES terms(id)
 );
@@ -44,6 +51,28 @@ CREATE TABLE IF NOT EXISTS lecturers (
     role TEXT CHECK(role IN ('lecturer','ta','lab')) DEFAULT 'lecturer'
 );
 
+-- مستخدمون بامتيازات إدارية
+CREATE TABLE IF NOT EXISTS admins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tg_user_id INTEGER NOT NULL UNIQUE,
+    username TEXT
+);
+
+-- مجموعات تيليجرام التي يتم الأرشفة منها
+CREATE TABLE IF NOT EXISTS groups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tg_chat_id INTEGER NOT NULL UNIQUE,
+    title TEXT
+);
+
+CREATE TABLE IF NOT EXISTS topics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id INTEGER NOT NULL,
+    tg_topic_id INTEGER NOT NULL,
+    title TEXT,
+    FOREIGN KEY (group_id) REFERENCES groups(id)
+);
+
 -- مواد تعليمية مرتبطة بالمادة + القسم + تصنيف المحتوى
 CREATE TABLE IF NOT EXISTS materials (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -59,9 +88,35 @@ CREATE TABLE IF NOT EXISTS materials (
     url TEXT,                 -- رابط تيليجرام/جوجل درايف/يوتيوب ... الخ
     year_id INTEGER,          -- اختياري
     lecturer_id INTEGER,      -- اختياري
+    tg_storage_chat_id INTEGER,
+    tg_storage_msg_id INTEGER,
+    source_chat_id INTEGER,
+    source_topic_id INTEGER,
+    source_message_id INTEGER,
+    created_by_admin_id INTEGER,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (subject_id) REFERENCES subjects(id),
     FOREIGN KEY (year_id) REFERENCES years(id),
-    FOREIGN KEY (lecturer_id) REFERENCES lecturers(id)
+    FOREIGN KEY (lecturer_id) REFERENCES lecturers(id),
+    FOREIGN KEY (created_by_admin_id) REFERENCES admins(id)
 );
+
+-- عمليات الاستيراد أو المعالجة الخلفية
+CREATE TABLE IF NOT EXISTS ingestions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    material_id INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (material_id) REFERENCES materials(id)
+);
+
+-- فهارس لتحسين الاستعلامات
+CREATE INDEX IF NOT EXISTS idx_materials_core
+    ON materials(subject_id, section, year_id, category);
+CREATE INDEX IF NOT EXISTS idx_materials_storage
+    ON materials(tg_storage_chat_id, tg_storage_msg_id);
+CREATE INDEX IF NOT EXISTS idx_topics_chat
+    ON topics(group_id, tg_topic_id);
+CREATE INDEX IF NOT EXISTS idx_ingestions_status
+    ON ingestions(status, created_at);
 


### PR DESCRIPTION
## Summary
- introduce DB v2 schema with admins, groups, topics and ingestions tables
- extend subjects and materials with extra metadata columns
- add migration logic and helpful indexes for efficient lookups

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import asyncio, os
from bot.db import init_db
asyncio.run(init_db())
print('init done')
print('db exists:', os.path.exists('database/archive.db'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a9d7ec15a8832981cb2a34e20d1704