### PR TITLE
Add owner seeding and update admins schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Telegram bot token
+BOT_TOKEN=
+
+# Telegram user ID for the bot owner
+OWNER_TG_ID=
+
+# Chat ID where files are stored
+STORAGE_CHAT_ID=
+

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -2,7 +2,7 @@ import os
 import aiosqlite
 
 DB_PATH = "database/archive.db"
-DB_VERSION = 2
+DB_VERSION = 3
 
 
 async def init_db() -> None:
@@ -36,7 +36,9 @@ async def migrate_if_needed() -> None:
                 CREATE TABLE IF NOT EXISTS admins (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     tg_user_id INTEGER NOT NULL UNIQUE,
-                    username TEXT
+                    username TEXT,
+                    role TEXT NOT NULL DEFAULT 'ADMIN',
+                    permissions_mask INTEGER NOT NULL DEFAULT 0
                 );
 
                 CREATE TABLE IF NOT EXISTS groups (
@@ -84,6 +86,13 @@ async def migrate_if_needed() -> None:
                     ON topics(group_id, tg_topic_id);
                 CREATE INDEX IF NOT EXISTS idx_ingestions_status
                     ON ingestions(status, created_at);
+                """
+            )
+        elif user_version < 3:
+            await db.executescript(
+                """
+                ALTER TABLE admins ADD COLUMN role TEXT NOT NULL DEFAULT 'ADMIN';
+                ALTER TABLE admins ADD COLUMN permissions_mask INTEGER NOT NULL DEFAULT 0;
                 """
             )
 

--- a/bot/db/seed_admins.py
+++ b/bot/db/seed_admins.py
@@ -1,0 +1,46 @@
+import os
+
+import aiosqlite
+from dotenv import load_dotenv
+
+from bot.config.constants import ENV_FILE
+from .base import DB_PATH
+
+FULL_ACCESS = 0xFFFFFFFF
+
+
+async def seed_owner() -> None:
+    """Seed database with OWNER admin based on OWNER_TG_ID env variable."""
+    load_dotenv(ENV_FILE)
+    owner_tg_id = os.getenv("OWNER_TG_ID")
+    if not owner_tg_id:
+        raise RuntimeError("OWNER_TG_ID is missing in environment")
+    tg_id = int(owner_tg_id)
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS admins (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tg_user_id INTEGER NOT NULL UNIQUE,
+                username TEXT,
+                role TEXT NOT NULL DEFAULT 'ADMIN',
+                permissions_mask INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        await db.execute(
+            """
+            INSERT OR IGNORE INTO admins (tg_user_id, role, permissions_mask)
+            VALUES (?, 'OWNER', ?)
+            """,
+            (tg_id, FULL_ACCESS),
+        )
+        await db.execute(
+            "UPDATE admins SET role='OWNER', permissions_mask=? WHERE tg_user_id=?",
+            (FULL_ACCESS, tg_id),
+        )
+        await db.commit()
+
+
+__all__ = ["seed_owner", "FULL_ACCESS"]

--- a/bot/seed_loader.py
+++ b/bot/seed_loader.py
@@ -10,7 +10,9 @@ from bot.db import (
     get_level_id_by_name,
     get_term_id_by_name,
     get_subject_id_by_name,
+    init_db,
 )
+from bot.db.seed_admins import seed_owner
 
 
 async def _ensure_level_id(name: str) -> int:
@@ -93,4 +95,16 @@ __all__ = [
     "load_years_and_lecturers",
     "load_materials",
 ]
+
+
+async def main() -> None:
+    """Entry point for seeding operations."""
+    await init_db()
+    await seed_owner()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())
 

--- a/database/init.sql
+++ b/database/init.sql
@@ -55,7 +55,9 @@ CREATE TABLE IF NOT EXISTS lecturers (
 CREATE TABLE IF NOT EXISTS admins (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     tg_user_id INTEGER NOT NULL UNIQUE,
-    username TEXT
+    username TEXT,
+    role TEXT NOT NULL DEFAULT 'ADMIN',
+    permissions_mask INTEGER NOT NULL DEFAULT 0
 );
 
 -- مجموعات تيليجرام التي يتم الأرشفة منها


### PR DESCRIPTION
## Summary
- add seed script to insert owner admin with full permissions
- upgrade admins table to store role and permissions mask
- provide `.env.example` with required variables

## Testing
- `python -m py_compile bot/db/seed_admins.py bot/db/base.py bot/seed_loader.py`
- `python -m bot.seed_loader`
- `sqlite3 database/archive.db "SELECT tg_user_id, role, permissions_mask FROM admins;"`


------
https://chatgpt.com/codex/tasks/task_e_68a9df8437c08329a78e274694f94f27