### PR TITLE
feat(db): add v2 schema and migration

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -1,4 +1,4 @@
-from .base import DB_PATH, init_db
+from .base import DB_PATH, init_db, migrate_if_needed
 from .subjects import (
     get_levels,
     get_level_id_by_name,
@@ -36,7 +36,7 @@ from .materials import (
 )
 
 __all__ = [
-    'DB_PATH', 'init_db',
+    'DB_PATH', 'init_db', 'migrate_if_needed',
     'get_levels', 'get_level_id_by_name', 'get_term_id_by_name',
     'insert_level', 'insert_term', 'insert_subject',
     'get_terms_by_level', 'get_subjects_by_level_and_term', 'get_subject_id_by_name',

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -4,10 +4,107 @@ import aiosqlite
 DB_PATH = "database/archive.db"
 
 
+async def _column_exists(db: aiosqlite.Connection, table: str, column: str) -> bool:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    cols = [row[1] for row in await cur.fetchall()]
+    return column in cols
+
+
+async def _migrate(db: aiosqlite.Connection) -> None:
+    """Apply additive schema updates (DB v2)."""
+    # subjects.sections_mode
+    if not await _column_exists(db, "subjects", "sections_mode"):
+        await db.execute(
+            """
+            ALTER TABLE subjects
+            ADD COLUMN sections_mode TEXT CHECK(sections_mode IN (
+                'theory_only','theory_discussion','theory_discussion_lab'
+            )) DEFAULT 'theory_discussion_lab'
+            """
+        )
+
+    # materials new columns
+    materials_cols = [
+        ("tg_storage_chat_id", "INTEGER"),
+        ("tg_storage_msg_id", "INTEGER"),
+        ("source_chat_id", "INTEGER"),
+        ("source_topic_id", "INTEGER"),
+        ("source_message_id", "INTEGER"),
+        ("created_by_admin_id", "INTEGER"),
+    ]
+    for col, col_type in materials_cols:
+        if not await _column_exists(db, "materials", col):
+            await db.execute(f"ALTER TABLE materials ADD COLUMN {col} {col_type}")
+
+    # new tables
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS admins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tg_user_id INTEGER UNIQUE,
+            name TEXT
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS groups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tg_chat_id INTEGER UNIQUE NOT NULL,
+            title TEXT
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS topics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            group_id INTEGER NOT NULL,
+            tg_topic_id INTEGER NOT NULL,
+            name TEXT,
+            FOREIGN KEY (group_id) REFERENCES groups(id)
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ingestions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            material_id INTEGER,
+            status TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (material_id) REFERENCES materials(id)
+        )
+        """
+    )
+
+    # indexes
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_materials_core ON materials(subject_id, section, year_id, category)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_materials_storage ON materials(tg_storage_chat_id, tg_storage_msg_id)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_topics_chat ON topics(group_id, tg_topic_id)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ingestions_status ON ingestions(status, created_at)"
+    )
+
+
+async def migrate_if_needed() -> None:
+    """Run migration on existing database."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await _migrate(db)
+        await db.commit()
+
+
 async def init_db() -> None:
-    """Ensure database folder exists and execute schema/init.sql once."""
+    """Ensure database folder exists and initialize schema, then migrate."""
     os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
     async with aiosqlite.connect(DB_PATH) as db:
         with open("database/init.sql", "r", encoding="utf-8") as f:
             await db.executescript(f.read())
+        await _migrate(db)
         await db.commit()

--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -28,14 +28,38 @@ async def insert_material(
     url: str | None = None,
     year_id: int | None = None,
     lecturer_id: int | None = None,
+    tg_storage_chat_id: int | None = None,
+    tg_storage_msg_id: int | None = None,
+    source_chat_id: int | None = None,
+    source_topic_id: int | None = None,
+    source_message_id: int | None = None,
+    created_by_admin_id: int | None = None,
 ):
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             """
-            INSERT INTO materials (subject_id, section, category, title, url, year_id, lecturer_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO materials (
+                subject_id, section, category, title, url, year_id, lecturer_id,
+                tg_storage_chat_id, tg_storage_msg_id, source_chat_id,
+                source_topic_id, source_message_id, created_by_admin_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (subject_id, section, category, title, url, year_id, lecturer_id),
+            (
+                subject_id,
+                section,
+                category,
+                title,
+                url,
+                year_id,
+                lecturer_id,
+                tg_storage_chat_id,
+                tg_storage_msg_id,
+                source_chat_id,
+                source_topic_id,
+                source_message_id,
+                created_by_admin_id,
+            ),
         )
         await db.commit()
 

--- a/database/init.sql
+++ b/database/init.sql
@@ -27,6 +27,9 @@ CREATE TABLE IF NOT EXISTS subjects (
     name TEXT NOT NULL,
     level_id INTEGER NOT NULL,
     term_id INTEGER NOT NULL,
+    sections_mode TEXT CHECK(sections_mode IN (
+        'theory_only','theory_discussion','theory_discussion_lab'
+    )) DEFAULT 'theory_discussion_lab',
     FOREIGN KEY (level_id) REFERENCES levels(id),
     FOREIGN KEY (term_id) REFERENCES terms(id)
 );
@@ -44,12 +47,43 @@ CREATE TABLE IF NOT EXISTS lecturers (
     role TEXT CHECK(role IN ('lecturer','ta','lab')) DEFAULT 'lecturer'
 );
 
+-- حسابات إدارية
+CREATE TABLE IF NOT EXISTS admins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tg_user_id INTEGER UNIQUE,
+    name TEXT
+);
+
+-- مجموعات تيليجرام
+CREATE TABLE IF NOT EXISTS groups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tg_chat_id INTEGER UNIQUE NOT NULL,
+    title TEXT
+);
+
+-- المواضيع داخل المجموعات
+CREATE TABLE IF NOT EXISTS topics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id INTEGER NOT NULL,
+    tg_topic_id INTEGER NOT NULL,
+    name TEXT,
+    FOREIGN KEY (group_id) REFERENCES groups(id)
+);
+
+-- عمليات الإدخال/الرفع
+CREATE TABLE IF NOT EXISTS ingestions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    material_id INTEGER,
+    status TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (material_id) REFERENCES materials(id)
+);
+
 -- مواد تعليمية مرتبطة بالمادة + القسم + تصنيف المحتوى
 CREATE TABLE IF NOT EXISTS materials (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     subject_id INTEGER NOT NULL,
     section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab','syllabus','apps')),
-    -- category TEXT NOT NULL CHECK(category IN ('lecture','exam','booklet','board_images','video','simulation','summary','notes','external_link')),
     category TEXT NOT NULL CHECK(category IN (
     'lecture','slides','audio','exam','booklet','board_images','video','simulation',
     'summary','notes','external_link','mind_map','transcript','related'
@@ -59,9 +93,15 @@ CREATE TABLE IF NOT EXISTS materials (
     url TEXT,                 -- رابط تيليجرام/جوجل درايف/يوتيوب ... الخ
     year_id INTEGER,          -- اختياري
     lecturer_id INTEGER,      -- اختياري
+    tg_storage_chat_id INTEGER,
+    tg_storage_msg_id INTEGER,
+    source_chat_id INTEGER,
+    source_topic_id INTEGER,
+    source_message_id INTEGER,
+    created_by_admin_id INTEGER,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (subject_id) REFERENCES subjects(id),
     FOREIGN KEY (year_id) REFERENCES years(id),
-    FOREIGN KEY (lecturer_id) REFERENCES lecturers(id)
+    FOREIGN KEY (lecturer_id) REFERENCES lecturers(id),
+    FOREIGN KEY (created_by_admin_id) REFERENCES admins(id)
 );
-


### PR DESCRIPTION
## Summary
- extend schema with admins, groups, topics, ingestions and optional sections_mode on subjects
- track material sources and storage locations
- provide migration logic for DB v2 with indexes

## Testing
- `python -m py_compile bot/db/base.py bot/db/materials.py bot/db/__init__.py`
- `python - <<'PY'
import asyncio
import aiosqlite
from bot.db import init_db, DB_PATH

async def test():
    await init_db()
    async with aiosqlite.connect(DB_PATH) as db:
        await db.execute("INSERT INTO levels (name) VALUES ('L1')")
        await db.execute("INSERT INTO terms (name) VALUES ('T1')")
        await db.execute("INSERT INTO subjects (code,name,level_id,term_id) VALUES ('S1','Subject1',1,1)")
        await db.execute("INSERT INTO years (name) VALUES ('1445/2024')")
        await db.execute("INSERT INTO lecturers (name,role) VALUES ('Lect1','lecturer')")
        await db.execute("INSERT INTO admins (tg_user_id,name) VALUES (123,'Admin1')")
        await db.execute("INSERT INTO groups (tg_chat_id,title) VALUES (456,'Group1')")
        await db.execute("INSERT INTO topics (group_id,tg_topic_id,name) VALUES (1,789,'Topic1')")
        await db.execute("""
            INSERT INTO materials (
                subject_id, section, category, title, url, year_id, lecturer_id,
                tg_storage_chat_id, tg_storage_msg_id, source_chat_id,
                source_topic_id, source_message_id, created_by_admin_id
            ) VALUES (1,'theory','lecture','Intro','http://example.com',1,1,111,222,333,444,555,1)
            """)
        await db.execute("INSERT INTO ingestions (material_id, status) VALUES (1,'pending')")
        await db.commit()
        for table in ['admins','groups','topics','ingestions','materials','subjects']:
            cur=await db.execute(f'SELECT COUNT(*) FROM {table}')
            print(table, await cur.fetchone())
        cur=await db.execute("PRAGMA index_list('materials')")
        print('materials indexes', await cur.fetchall())
        cur=await db.execute("PRAGMA index_list('topics')")
        print('topics indexes', await cur.fetchall())
        cur=await db.execute("PRAGMA index_list('ingestions')")
        print('ingestions indexes', await cur.fetchall())

asyncio.run(test())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a9f1097cb88329b4b082403bf57a57