### PR TITLE
feat(seed): seed owner from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+BOT_TOKEN=
+ARCHIVE_CHANNEL_ID=
+GROUP_ID=
+ADMIN_USER_IDS=
+# Telegram user ID of the bot owner
+OWNER_TG_ID=
+

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -42,10 +42,23 @@ async def _migrate(db: aiosqlite.Connection) -> None:
         CREATE TABLE IF NOT EXISTS admins (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             tg_user_id INTEGER UNIQUE,
-            name TEXT
+            name TEXT,
+            role TEXT NOT NULL,
+            permissions_mask INTEGER NOT NULL,
+            is_active INTEGER NOT NULL DEFAULT 1
         )
         """
     )
+    admin_cols = [
+        ("role", "TEXT", "'ADMIN'"),
+        ("permissions_mask", "INTEGER", "0"),
+        ("is_active", "INTEGER", "1"),
+    ]
+    for col, col_type, default in admin_cols:
+        if not await _column_exists(db, "admins", col):
+            await db.execute(
+                f"ALTER TABLE admins ADD COLUMN {col} {col_type} DEFAULT {default}"
+            )
     await db.execute(
         """
         CREATE TABLE IF NOT EXISTS groups (

--- a/bot/db/seed_admins.py
+++ b/bot/db/seed_admins.py
@@ -1,0 +1,52 @@
+"""Utility to seed admin accounts.
+
+Currently only supports inserting the bot owner with full permissions.
+"""
+
+from __future__ import annotations
+
+import os
+
+import aiosqlite
+from dotenv import load_dotenv
+
+from .base import DB_PATH
+
+ENV_FILE = ".env"
+
+ROLE_OWNER = "OWNER"
+FULL_ACCESS = 0xFFFFFFFF
+
+
+async def seed_owner() -> None:
+    """Create or update the bot owner in the admins table.
+
+    The Telegram user id is read from ``OWNER_TG_ID`` environment variable.
+    The operation is idempotent: running it multiple times will not create
+    duplicate records and will ensure the owner stays active with full access.
+    """
+
+    load_dotenv(ENV_FILE)
+    owner_id = os.getenv("OWNER_TG_ID")
+    if not owner_id:
+        raise RuntimeError("OWNER_TG_ID is missing in environment")
+
+    tg_user_id = int(owner_id)
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT INTO admins (tg_user_id, role, permissions_mask, is_active)
+            VALUES (?, ?, ?, 1)
+            ON CONFLICT(tg_user_id) DO UPDATE SET
+                role=excluded.role,
+                permissions_mask=excluded.permissions_mask,
+                is_active=1
+            """,
+            (tg_user_id, ROLE_OWNER, FULL_ACCESS),
+        )
+        await db.commit()
+
+
+__all__ = ["seed_owner"]
+

--- a/bot/seed_loader.py
+++ b/bot/seed_loader.py
@@ -10,7 +10,9 @@ from bot.db import (
     get_level_id_by_name,
     get_term_id_by_name,
     get_subject_id_by_name,
+    init_db,
 )
+from .db.seed_admins import seed_owner
 
 
 async def _ensure_level_id(name: str) -> int:
@@ -92,5 +94,23 @@ __all__ = [
     "load_structure",
     "load_years_and_lecturers",
     "load_materials",
+    "main",
 ]
+
+
+async def main() -> None:
+    import json
+
+    await init_db()
+    payload = json.load(open("seed_data.json", encoding="utf-8"))
+    await load_structure(payload["levels"])
+    await load_years_and_lecturers(payload["years"], payload["lecturers"])
+    await load_materials(payload["materials"])
+    await seed_owner()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())
 

--- a/database/init.sql
+++ b/database/init.sql
@@ -48,11 +48,14 @@ CREATE TABLE IF NOT EXISTS lecturers (
 );
 
 -- حسابات إدارية
-CREATE TABLE IF NOT EXISTS admins (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    tg_user_id INTEGER UNIQUE,
-    name TEXT
-);
+ CREATE TABLE IF NOT EXISTS admins (
+     id INTEGER PRIMARY KEY AUTOINCREMENT,
+     tg_user_id INTEGER UNIQUE,
+     name TEXT,
+     role TEXT NOT NULL,
+     permissions_mask INTEGER NOT NULL,
+     is_active INTEGER NOT NULL DEFAULT 1
+ );
 
 -- مجموعات تيليجرام
 CREATE TABLE IF NOT EXISTS groups (


### PR DESCRIPTION
## Summary
- seed bot owner from `OWNER_TG_ID` env var
- wire owner seeding into main seed loader
- document owner id in env example

## Testing
- `python -m bot.seed_loader`
- `sqlite3 database/archive.db "SELECT id, tg_user_id, role, permissions_mask, is_active FROM admins;"`


------
https://chatgpt.com/codex/tasks/task_e_68a9f354330c83299172ca38ab44cce6