### PR TITLE
feat: add topic subject linking via /insert_sub

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -34,6 +34,12 @@ from .materials import (
     list_categories_for_subject_section_year,
     list_categories_for_lecture,
 )
+from .topics import (
+    is_admin,
+    get_group_id_by_chat,
+    get_subject_by_name,
+    upsert_topic,
+)
 
 __all__ = [
     'DB_PATH', 'init_db', 'migrate_if_needed',
@@ -49,4 +55,5 @@ __all__ = [
     'get_years_for_subject_section_lecturer', 'get_lecture_materials',
     'get_materials_by_category', 'list_categories_for_subject_section_year',
     'list_categories_for_lecture',
+    'is_admin', 'get_group_id_by_chat', 'get_subject_by_name', 'upsert_topic',
 ]

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -74,11 +74,19 @@ async def _migrate(db: aiosqlite.Connection) -> None:
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             group_id INTEGER NOT NULL,
             tg_topic_id INTEGER NOT NULL,
-            name TEXT,
-            FOREIGN KEY (group_id) REFERENCES groups(id)
+            subject_id INTEGER NOT NULL,
+            section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab')),
+            FOREIGN KEY (group_id) REFERENCES groups(id),
+            FOREIGN KEY (subject_id) REFERENCES subjects(id),
+            UNIQUE (group_id, tg_topic_id)
         )
         """
     )
+
+    topic_cols = [("subject_id", "INTEGER"), ("section", "TEXT")]
+    for col, col_type in topic_cols:
+        if not await _column_exists(db, "topics", col):
+            await db.execute(f"ALTER TABLE topics ADD COLUMN {col} {col_type}")
     await db.execute(
         """
         CREATE TABLE IF NOT EXISTS ingestions (
@@ -99,7 +107,7 @@ async def _migrate(db: aiosqlite.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_materials_storage ON materials(tg_storage_chat_id, tg_storage_msg_id)"
     )
     await db.execute(
-        "CREATE INDEX IF NOT EXISTS idx_topics_chat ON topics(group_id, tg_topic_id)"
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_topics_chat ON topics(group_id, tg_topic_id)"
     )
     await db.execute(
         "CREATE INDEX IF NOT EXISTS idx_ingestions_status ON ingestions(status, created_at)"

--- a/bot/db/topics.py
+++ b/bot/db/topics.py
@@ -1,0 +1,54 @@
+import aiosqlite
+
+from .base import DB_PATH
+
+
+async def is_admin(tg_user_id: int) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT 1 FROM admins WHERE tg_user_id=? AND is_active=1", (tg_user_id,)
+        )
+        return (await cur.fetchone()) is not None
+
+
+async def get_group_id_by_chat(tg_chat_id: int) -> int | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id FROM groups WHERE tg_chat_id=?", (tg_chat_id,)
+        )
+        row = await cur.fetchone()
+        return row[0] if row else None
+
+
+async def get_subject_by_name(name: str) -> tuple[int, str] | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, sections_mode FROM subjects WHERE name=?", (name,)
+        )
+        row = await cur.fetchone()
+        return (row[0], row[1]) if row else None
+
+
+async def upsert_topic(
+    group_id: int, tg_topic_id: int, subject_id: int, section: str
+) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT INTO topics (group_id, tg_topic_id, subject_id, section)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(group_id, tg_topic_id) DO UPDATE SET
+                subject_id=excluded.subject_id,
+                section=excluded.section
+            """,
+            (group_id, tg_topic_id, subject_id, section),
+        )
+        await db.commit()
+
+
+__all__ = [
+    "is_admin",
+    "get_group_id_by_chat",
+    "get_subject_by_name",
+    "upsert_topic",
+]

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -1,4 +1,5 @@
 from .start import start
 from .navigation import render_state, echo_handler
+from .topics import insert_sub_conv
 
-__all__ = ["start", "render_state", "echo_handler"]
+__all__ = ["start", "render_state", "echo_handler", "insert_sub_conv"]

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+)
+from telegram.ext import (
+    CommandHandler,
+    MessageHandler,
+    CallbackQueryHandler,
+    ConversationHandler,
+    ContextTypes,
+    filters,
+)
+
+from bot.db import (
+    is_admin,
+    get_group_id_by_chat,
+    get_subject_by_name,
+    upsert_topic,
+)
+
+ASK_INPUT, CONFIRM = range(2)
+
+SECTION_ALIASES = {
+    "نظري": "theory",
+    "مناقشة": "discussion",
+    "مناقشه": "discussion",
+    "عملي": "lab",
+    "theory": "theory",
+    "discussion": "discussion",
+    "lab": "lab",
+}
+
+
+async def insert_sub_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    user = update.effective_user
+    chat = update.effective_chat
+
+    if not message or message.message_thread_id is None:
+        await message.reply_text("استخدم هذا الأمر داخل موضوع ضمن مجموعة.")
+        return ConversationHandler.END
+
+    if not await is_admin(user.id):
+        await message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
+        return ConversationHandler.END
+
+    group_id = await get_group_id_by_chat(chat.id)
+    if group_id is None:
+        await message.reply_text("المجموعة غير مسجلة. استخدم /insert_group أولًا.")
+        return ConversationHandler.END
+
+    context.user_data["insert_sub"] = {
+        "group_id": group_id,
+        "thread_id": message.message_thread_id,
+        "cmd_msg_id": message.message_id,
+        "chat_id": chat.id,
+    }
+
+    await message.reply_text("أرسل اسم المادة متبوعًا بالقسم (مثال: فيزياء - نظري)")
+    return ASK_INPUT
+
+
+async def insert_sub_received(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    info = context.user_data.get("insert_sub")
+    if not info:
+        return ConversationHandler.END
+
+    text = update.message.text.strip()
+    parts = [p.strip() for p in text.split("-", 1)]
+    subj_name = parts[0]
+    sect_label = parts[1] if len(parts) > 1 else None
+
+    row = await get_subject_by_name(subj_name)
+    if row is None:
+        await update.message.reply_text("المادة غير موجودة، حاول مرة أخرى.")
+        return ASK_INPUT
+
+    subject_id, mode = row
+    section = "theory"
+    if mode == "theory_only":
+        sect_label = "نظري"
+    else:
+        if sect_label is None:
+            await update.message.reply_text("حدد القسم أيضًا (نظري/مناقشة/عملي).")
+            return ASK_INPUT
+        section = SECTION_ALIASES.get(sect_label.lower())
+        if section is None:
+            await update.message.reply_text("القسم غير معروف، استخدم: نظري، مناقشة، عملي.")
+            return ASK_INPUT
+        if mode == "theory_discussion" and section == "lab":
+            await update.message.reply_text("هذا المقرر لا يحتوي على قسم عملي.")
+            return ASK_INPUT
+
+    info.update(
+        {
+            "subject_id": subject_id,
+            "subject_name": subj_name,
+            "section": section,
+            "input_msg_id": update.message.message_id,
+        }
+    )
+
+    buttons = [
+        [
+            InlineKeyboardButton("تأكيد", callback_data="insub_confirm"),
+            InlineKeyboardButton("تعديل", callback_data="insub_edit"),
+            InlineKeyboardButton("إلغاء", callback_data="insub_cancel"),
+        ]
+    ]
+    reply = f"المادة: {subj_name}\nالقسم: {sect_label or 'نظري'}\nهل تؤكد؟"
+    sent = await update.message.reply_text(
+        reply, reply_markup=InlineKeyboardMarkup(buttons)
+    )
+    info["confirm_msg_id"] = sent.message_id
+
+    return CONFIRM
+
+
+async def insert_sub_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.answer()
+    data = query.data
+    info = context.user_data.get("insert_sub")
+    if not info:
+        await query.edit_message_text("انتهت الجلسة.")
+        return ConversationHandler.END
+
+    chat_id = info["chat_id"]
+    bot = context.bot
+
+    if data == "insub_confirm":
+        await upsert_topic(
+            info["group_id"], info["thread_id"], info["subject_id"], info["section"]
+        )
+        await query.edit_message_text("تم الحفظ بنجاح.")
+        for key in ("cmd_msg_id", "input_msg_id"):
+            msg_id = info.get(key)
+            if msg_id:
+                try:
+                    await bot.delete_message(chat_id, msg_id)
+                except Exception:
+                    pass
+        context.user_data.pop("insert_sub", None)
+        return ConversationHandler.END
+
+    if data == "insub_edit":
+        msg_id = info.get("input_msg_id")
+        if msg_id:
+            try:
+                await bot.delete_message(chat_id, msg_id)
+            except Exception:
+                pass
+            info.pop("input_msg_id", None)
+        await query.edit_message_text("أرسل اسم المادة والقسم مرة أخرى.")
+        return ASK_INPUT
+
+    # cancel
+    await query.edit_message_text("تم الإلغاء.")
+    for key in ("cmd_msg_id", "input_msg_id"):
+        msg_id = info.get(key)
+        if msg_id:
+            try:
+                await bot.delete_message(chat_id, msg_id)
+            except Exception:
+                pass
+    context.user_data.pop("insert_sub", None)
+    return ConversationHandler.END
+
+
+insert_sub_conv = ConversationHandler(
+    entry_points=[CommandHandler("insert_sub", insert_sub_start)],
+    states={
+        ASK_INPUT: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, insert_sub_received)
+        ],
+        CONFIRM: [CallbackQueryHandler(insert_sub_confirm, pattern="^insub_")],
+    },
+    fallbacks=[],
+)
+
+__all__ = ["insert_sub_conv"]

--- a/bot/main.py
+++ b/bot/main.py
@@ -14,7 +14,7 @@ from telegram.ext import (
 
 from bot.config import BOT_TOKEN
 from bot.db import init_db
-from .handlers import start, echo_handler
+from .handlers import start, echo_handler, insert_sub_conv
 
 # --------------------------------------------------------------------------
 # إعداد التسجيل لرؤية الرسائل التفصيلية
@@ -44,6 +44,7 @@ def main():
 
     app = ApplicationBuilder().token(BOT_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
+    app.add_handler(insert_sub_conv)
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, echo_handler))
 
     print("✅ Bot is running...")

--- a/database/init.sql
+++ b/database/init.sql
@@ -69,9 +69,15 @@ CREATE TABLE IF NOT EXISTS topics (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     group_id INTEGER NOT NULL,
     tg_topic_id INTEGER NOT NULL,
-    name TEXT,
-    FOREIGN KEY (group_id) REFERENCES groups(id)
+    subject_id INTEGER NOT NULL,
+    section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab')),
+    FOREIGN KEY (group_id) REFERENCES groups(id),
+    FOREIGN KEY (subject_id) REFERENCES subjects(id),
+    UNIQUE (group_id, tg_topic_id)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_topics_chat
+ON topics(group_id, tg_topic_id);
 
 -- عمليات الإدخال/الرفع
 CREATE TABLE IF NOT EXISTS ingestions (


### PR DESCRIPTION
## Summary
- extend topics table to link to subjects and sections
- add database helpers and conversation handler for /insert_sub
- wire /insert_sub handler into bot application

## Testing
- `python -m py_compile bot/db/base.py bot/db/topics.py bot/db/__init__.py bot/handlers/topics.py bot/handlers/__init__.py bot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9f57154b48329a6244758de3bf074