### PR TITLE
feat: handle hashtag ingestion pending flow

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -40,6 +40,11 @@ from .topics import (
     get_subject_by_name,
     upsert_topic,
 )
+from .ingestions import (
+    get_admin_id_by_tg_user,
+    insert_ingestion,
+    attach_material,
+)
 
 __all__ = [
     'DB_PATH', 'init_db', 'migrate_if_needed',
@@ -56,4 +61,5 @@ __all__ = [
     'get_materials_by_category', 'list_categories_for_subject_section_year',
     'list_categories_for_lecture',
     'is_admin', 'get_group_id_by_chat', 'get_subject_by_name', 'upsert_topic',
+    'get_admin_id_by_tg_user', 'insert_ingestion', 'attach_material',
 ]

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -93,11 +93,19 @@ async def _migrate(db: aiosqlite.Connection) -> None:
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             material_id INTEGER,
             status TEXT NOT NULL,
+            tg_message_id INTEGER,
+            admin_id INTEGER,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (material_id) REFERENCES materials(id)
+            FOREIGN KEY (material_id) REFERENCES materials(id),
+            FOREIGN KEY (admin_id) REFERENCES admins(id)
         )
         """
     )
+
+    ingestion_cols = [("tg_message_id", "INTEGER"), ("admin_id", "INTEGER")]
+    for col, col_type in ingestion_cols:
+        if not await _column_exists(db, "ingestions", col):
+            await db.execute(f"ALTER TABLE ingestions ADD COLUMN {col} {col_type}")
 
     # indexes
     await db.execute(

--- a/bot/db/ingestions.py
+++ b/bot/db/ingestions.py
@@ -1,0 +1,43 @@
+import aiosqlite
+
+from .base import DB_PATH
+
+
+async def get_admin_id_by_tg_user(tg_user_id: int) -> int | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id FROM admins WHERE tg_user_id=? AND is_active=1",
+            (tg_user_id,),
+        )
+        row = await cur.fetchone()
+        return row[0] if row else None
+
+
+async def insert_ingestion(
+    tg_message_id: int, admin_id: int, status: str = "pending"
+) -> int:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            """
+            INSERT INTO ingestions (tg_message_id, admin_id, status)
+            VALUES (?, ?, ?)
+            """,
+            (tg_message_id, admin_id, status),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def attach_material(
+    ingestion_id: int, material_id: int, status: str = "approved"
+) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE ingestions SET material_id=?, status=? WHERE id=?",
+            (material_id, status, ingestion_id),
+        )
+        await db.commit()
+
+
+__all__ = ["get_admin_id_by_tg_user", "insert_ingestion", "attach_material"]
+

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -1,5 +1,12 @@
 from .start import start
 from .navigation import render_state, echo_handler
 from .topics import insert_sub_conv
+from .ingestion import ingestion_handler
 
-__all__ = ["start", "render_state", "echo_handler", "insert_sub_conv"]
+__all__ = [
+    "start",
+    "render_state",
+    "echo_handler",
+    "insert_sub_conv",
+    "ingestion_handler",
+]

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -1,0 +1,40 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ..db.ingestions import get_admin_id_by_tg_user, insert_ingestion
+from ..db.topics import is_admin
+
+
+def _extract_hashtags(update: Update) -> list[str]:
+    msg = update.message
+    if not msg:
+        return []
+    text = msg.text or msg.caption or ""
+    entities = msg.entities or msg.caption_entities or []
+    tags = []
+    for ent in entities:
+        if ent.type == "hashtag":
+            tags.append(text[ent.offset : ent.offset + ent.length])
+    return tags
+
+
+async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    tags = _extract_hashtags(update)
+    if not tags:
+        return
+
+    user = update.effective_user
+    if not user or not await is_admin(user.id):
+        return
+
+    admin_id = await get_admin_id_by_tg_user(user.id)
+    if admin_id is None:
+        return
+
+    message = update.effective_message
+    ingestion_id = await insert_ingestion(message.message_id, admin_id)
+    await message.reply_text(f"✅ {ingestion_id}")
+
+
+__all__ = ["ingestion_handler"]
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -14,7 +14,7 @@ from telegram.ext import (
 
 from bot.config import BOT_TOKEN
 from bot.db import init_db
-from .handlers import start, echo_handler, insert_sub_conv
+from .handlers import start, echo_handler, insert_sub_conv, ingestion_handler
 
 # --------------------------------------------------------------------------
 # إعداد التسجيل لرؤية الرسائل التفصيلية
@@ -45,6 +45,7 @@ def main():
     app = ApplicationBuilder().token(BOT_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
     app.add_handler(insert_sub_conv)
+    app.add_handler(MessageHandler(filters.ALL, ingestion_handler))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, echo_handler))
 
     print("✅ Bot is running...")

--- a/database/init.sql
+++ b/database/init.sql
@@ -84,8 +84,11 @@ CREATE TABLE IF NOT EXISTS ingestions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     material_id INTEGER,
     status TEXT NOT NULL,
+    tg_message_id INTEGER,
+    admin_id INTEGER,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (material_id) REFERENCES materials(id)
+    FOREIGN KEY (material_id) REFERENCES materials(id),
+    FOREIGN KEY (admin_id) REFERENCES admins(id)
 );
 
 -- مواد تعليمية مرتبطة بالمادة + القسم + تصنيف المحتوى


### PR DESCRIPTION
## Summary
- handle hashtag messages from admins and store a pending ingestion entry
- provide DB helpers for ingestions and expose them
- extend database schema with message/admin references and wire handler into bot startup

## Testing
- `python -m py_compile bot/main.py bot/handlers/ingestion.py bot/db/ingestions.py bot/db/base.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f762edf083298f9207c2019d0db8