### PR TITLE
feat: allow editing existing topic subject

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -38,6 +38,7 @@ from .topics import (
     is_admin,
     get_group_id_by_chat,
     get_subject_by_name,
+    get_topic_link,
     upsert_topic,
 )
 from .ingestions import (
@@ -60,6 +61,6 @@ __all__ = [
     'get_years_for_subject_section_lecturer', 'get_lecture_materials',
     'get_materials_by_category', 'list_categories_for_subject_section_year',
     'list_categories_for_lecture',
-    'is_admin', 'get_group_id_by_chat', 'get_subject_by_name', 'upsert_topic',
+    'is_admin', 'get_group_id_by_chat', 'get_subject_by_name', 'get_topic_link', 'upsert_topic',
     'get_admin_id_by_tg_user', 'insert_ingestion', 'attach_material',
 ]

--- a/bot/db/topics.py
+++ b/bot/db/topics.py
@@ -29,6 +29,28 @@ async def get_subject_by_name(name: str) -> tuple[int, str] | None:
         return (row[0], row[1]) if row else None
 
 
+async def get_topic_link(
+    group_id: int, tg_topic_id: int
+) -> tuple[int, str, str] | None:
+    """Return existing topic linkage if present.
+
+    Returns a tuple of (subject_id, subject_name, section)
+    or ``None`` if the topic is not linked yet.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            """
+            SELECT t.subject_id, s.name, t.section
+            FROM topics t
+            JOIN subjects s ON s.id = t.subject_id
+            WHERE t.group_id=? AND t.tg_topic_id=?
+            """,
+            (group_id, tg_topic_id),
+        )
+        row = await cur.fetchone()
+        return (row[0], row[1], row[2]) if row else None
+
+
 async def upsert_topic(
     group_id: int, tg_topic_id: int, subject_id: int, section: str
 ) -> None:
@@ -50,5 +72,6 @@ __all__ = [
     "is_admin",
     "get_group_id_by_chat",
     "get_subject_by_name",
+    "get_topic_link",
     "upsert_topic",
 ]

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -18,6 +18,7 @@ from bot.db import (
     is_admin,
     get_group_id_by_chat,
     get_subject_by_name,
+    get_topic_link,
     upsert_topic,
 )
 
@@ -31,6 +32,12 @@ SECTION_ALIASES = {
     "theory": "theory",
     "discussion": "discussion",
     "lab": "lab",
+}
+
+SECTION_LABELS = {
+    "theory": "نظري",
+    "discussion": "مناقشة",
+    "lab": "عملي",
 }
 
 
@@ -51,13 +58,35 @@ async def insert_sub_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if group_id is None:
         await message.reply_text("المجموعة غير مسجلة. استخدم /insert_group أولًا.")
         return ConversationHandler.END
+    thread_id = message.message_thread_id
 
     context.user_data["insert_sub"] = {
         "group_id": group_id,
-        "thread_id": message.message_thread_id,
+        "thread_id": thread_id,
         "cmd_msg_id": message.message_id,
         "chat_id": chat.id,
     }
+
+    existing = await get_topic_link(group_id, thread_id)
+    if existing:
+        subject_id, subject_name, section = existing
+        context.user_data["insert_sub"].update(
+            {"subject_id": subject_id, "subject_name": subject_name, "section": section}
+        )
+        buttons = [[
+            InlineKeyboardButton("تعديل", callback_data="insub_edit"),
+            InlineKeyboardButton("إلغاء", callback_data="insub_cancel"),
+        ]]
+        reply = (
+            f"الموضوع مرتبط حاليًا بـ:\n"
+            f"المادة: {subject_name}\n"
+            f"القسم: {SECTION_LABELS.get(section, section)}"
+        )
+        sent = await message.reply_text(
+            reply, reply_markup=InlineKeyboardMarkup(buttons)
+        )
+        context.user_data["insert_sub"]["confirm_msg_id"] = sent.message_id
+        return CONFIRM
 
     await message.reply_text("أرسل اسم المادة متبوعًا بالقسم (مثال: فيزياء - نظري)")
     return ASK_INPUT


### PR DESCRIPTION
## Summary
- show current subject for topic when using /insert_sub
- allow admins to edit or cancel existing linkage
- expose DB helper to fetch topic link

## Testing
- `pytest`
- `python -m py_compile bot/db/topics.py bot/db/__init__.py bot/handlers/topics.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc6dc1f0832991b530c28dc24fe3