### PR TITLE
Fix ingestion handler filtering

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -45,7 +45,10 @@ def main():
     app = ApplicationBuilder().token(BOT_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
     app.add_handler(insert_sub_conv)
-    app.add_handler(MessageHandler(filters.ALL, ingestion_handler))
+    app.add_handler(
+        MessageHandler(filters.Entity("hashtag"), ingestion_handler),
+        group=1,
+    )
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, echo_handler))
 
     print("✅ Bot is running...")


### PR DESCRIPTION
## Summary
- Only trigger ingestion handler on messages containing hashtags
- Run ingestion handler in later group to avoid blocking other handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aa076239608329a47407c172b54492