### PR TITLE
Add interactive /insert_group handler

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -41,6 +41,10 @@ from .topics import (
     get_topic_link,
     upsert_topic,
 )
+from .groups import (
+    get_group_info,
+    upsert_group,
+)
 from .ingestions import (
     get_admin_id_by_tg_user,
     insert_ingestion,
@@ -62,5 +66,6 @@ __all__ = [
     'get_materials_by_category', 'list_categories_for_subject_section_year',
     'list_categories_for_lecture',
     'is_admin', 'get_group_id_by_chat', 'get_subject_by_name', 'get_topic_link', 'upsert_topic',
+    'get_group_info', 'upsert_group',
     'get_admin_id_by_tg_user', 'insert_ingestion', 'attach_material',
 ]

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -64,10 +64,18 @@ async def _migrate(db: aiosqlite.Connection) -> None:
         CREATE TABLE IF NOT EXISTS groups (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             tg_chat_id INTEGER UNIQUE NOT NULL,
-            title TEXT
+            title TEXT,
+            level_id INTEGER,
+            term_id INTEGER,
+            FOREIGN KEY (level_id) REFERENCES levels(id),
+            FOREIGN KEY (term_id) REFERENCES terms(id)
         )
         """
     )
+    group_cols = [("level_id", "INTEGER"), ("term_id", "INTEGER")]
+    for col, col_type in group_cols:
+        if not await _column_exists(db, "groups", col):
+            await db.execute(f"ALTER TABLE groups ADD COLUMN {col} {col_type}")
     await db.execute(
         """
         CREATE TABLE IF NOT EXISTS topics (

--- a/bot/db/groups.py
+++ b/bot/db/groups.py
@@ -1,0 +1,32 @@
+import aiosqlite
+
+from .base import DB_PATH
+
+
+async def get_group_info(tg_chat_id: int) -> tuple[int, int] | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT level_id, term_id FROM groups WHERE tg_chat_id=?",
+            (tg_chat_id,),
+        )
+        row = await cur.fetchone()
+        return (row[0], row[1]) if row else None
+
+
+async def upsert_group(tg_chat_id: int, level_id: int, term_id: int, title: str) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT INTO groups (tg_chat_id, title, level_id, term_id)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(tg_chat_id) DO UPDATE SET
+                title=excluded.title,
+                level_id=excluded.level_id,
+                term_id=excluded.term_id
+            """,
+            (tg_chat_id, title, level_id, term_id),
+        )
+        await db.commit()
+
+
+__all__ = ["get_group_info", "upsert_group"]

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -1,6 +1,7 @@
 from .start import start
 from .navigation import render_state, echo_handler
 from .topics import insert_sub_conv
+from .groups import insert_group_conv
 from .ingestion import ingestion_handler
 
 __all__ = [
@@ -8,5 +9,6 @@ __all__ = [
     "render_state",
     "echo_handler",
     "insert_sub_conv",
+    "insert_group_conv",
     "ingestion_handler",
 ]

--- a/bot/handlers/groups.py
+++ b/bot/handlers/groups.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+)
+from telegram.ext import (
+    CommandHandler,
+    MessageHandler,
+    CallbackQueryHandler,
+    ConversationHandler,
+    ContextTypes,
+    filters,
+)
+
+from bot.db import (
+    is_admin,
+    get_level_id_by_name,
+    get_term_id_by_name,
+    get_group_info,
+    upsert_group,
+)
+
+ASK_INPUT, CONFIRM = range(2)
+
+
+async def insert_group_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    user = update.effective_user
+    chat = update.effective_chat
+
+    if not await is_admin(user.id):
+        await message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
+        return ConversationHandler.END
+
+    info = {
+        "tg_chat_id": chat.id,
+        "chat_id": chat.id,
+        "cmd_msg_id": message.message_id,
+    }
+    context.user_data["insert_group"] = info
+
+    existing = await get_group_info(chat.id)
+    if existing:
+        level_id, term_id = existing
+        info.update({"level_id": level_id, "term_id": term_id})
+        buttons = [[
+            InlineKeyboardButton("تعديل", callback_data="ingrp_edit"),
+            InlineKeyboardButton("إلغاء", callback_data="ingrp_cancel"),
+        ]]
+        reply = f"المجموعة مرتبطة حاليًا بالمستوى {level_id} - الترم {term_id}"
+        sent = await message.reply_text(reply, reply_markup=InlineKeyboardMarkup(buttons))
+        info["confirm_msg_id"] = sent.message_id
+        return CONFIRM
+
+    await message.reply_text("أرسل المستوى متبوعًا بالترم (مثال: المستوى الأول - الترم الثاني)")
+    return ASK_INPUT
+
+
+async def insert_group_received(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    info = context.user_data.get("insert_group")
+    if not info:
+        return ConversationHandler.END
+
+    text = update.message.text.strip()
+    parts = [p.strip() for p in text.split("-", 1)]
+    level_name = parts[0]
+    term_name = parts[1] if len(parts) > 1 else None
+
+    level_id = await get_level_id_by_name(level_name)
+    if level_id is None:
+        await update.message.reply_text("المستوى غير معروف، حاول مرة أخرى.")
+        return ASK_INPUT
+
+    if term_name is None:
+        await update.message.reply_text("حدد الترم أيضًا.")
+        return ASK_INPUT
+
+    term_id = await get_term_id_by_name(term_name)
+    if term_id is None:
+        await update.message.reply_text("الترم غير معروف، حاول مرة أخرى.")
+        return ASK_INPUT
+
+    info.update(
+        {
+            "level_id": level_id,
+            "term_id": term_id,
+            "input_msg_id": update.message.message_id,
+            "level_name": level_name,
+            "term_name": term_name,
+        }
+    )
+
+    buttons = [[
+        InlineKeyboardButton("تأكيد", callback_data="ingrp_confirm"),
+        InlineKeyboardButton("تعديل", callback_data="ingrp_edit"),
+        InlineKeyboardButton("إلغاء", callback_data="ingrp_cancel"),
+    ]]
+    reply = f"المستوى: {level_name}\nالترم: {term_name}\nهل تؤكد؟"
+    sent = await update.message.reply_text(reply, reply_markup=InlineKeyboardMarkup(buttons))
+    info["confirm_msg_id"] = sent.message_id
+
+    return CONFIRM
+
+
+async def insert_group_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.answer()
+    data = query.data
+    info = context.user_data.get("insert_group")
+    if not info:
+        await query.edit_message_text("انتهت الجلسة.")
+        return ConversationHandler.END
+
+    chat_id = info["chat_id"]
+    bot = context.bot
+
+    if data == "ingrp_confirm":
+        title = update.effective_chat.title or ""
+        await upsert_group(info["tg_chat_id"], info["level_id"], info["term_id"], title)
+        await query.edit_message_text("تم الحفظ بنجاح.")
+        for key in ("cmd_msg_id", "input_msg_id"):
+            msg_id = info.get(key)
+            if msg_id:
+                try:
+                    await bot.delete_message(chat_id, msg_id)
+                except Exception:
+                    pass
+        context.user_data.pop("insert_group", None)
+        return ConversationHandler.END
+
+    if data == "ingrp_edit":
+        msg_id = info.get("input_msg_id")
+        if msg_id:
+            try:
+                await bot.delete_message(chat_id, msg_id)
+            except Exception:
+                pass
+            info.pop("input_msg_id", None)
+        await query.edit_message_text("أرسل المستوى والترم مرة أخرى.")
+        return ASK_INPUT
+
+    # cancel
+    await query.edit_message_text("تم الإلغاء.")
+    for key in ("cmd_msg_id", "input_msg_id"):
+        msg_id = info.get(key)
+        if msg_id:
+            try:
+                await bot.delete_message(chat_id, msg_id)
+            except Exception:
+                pass
+    context.user_data.pop("insert_group", None)
+    return ConversationHandler.END
+
+
+insert_group_conv = ConversationHandler(
+    entry_points=[CommandHandler("insert_group", insert_group_start)],
+    states={
+        ASK_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, insert_group_received)],
+        CONFIRM: [CallbackQueryHandler(insert_group_confirm, pattern="^ingrp_")],
+    },
+    fallbacks=[],
+)
+
+__all__ = ["insert_group_conv"]

--- a/bot/main.py
+++ b/bot/main.py
@@ -14,7 +14,13 @@ from telegram.ext import (
 
 from bot.config import BOT_TOKEN
 from bot.db import init_db
-from .handlers import start, echo_handler, insert_sub_conv, ingestion_handler
+from .handlers import (
+    start,
+    echo_handler,
+    insert_sub_conv,
+    ingestion_handler,
+    insert_group_conv,
+)
 
 # --------------------------------------------------------------------------
 # إعداد التسجيل لرؤية الرسائل التفصيلية
@@ -44,6 +50,7 @@ def main():
 
     app = ApplicationBuilder().token(BOT_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
+    app.add_handler(insert_group_conv)
     app.add_handler(insert_sub_conv)
     app.add_handler(
         MessageHandler(filters.Entity("hashtag"), ingestion_handler),

--- a/database/init.sql
+++ b/database/init.sql
@@ -61,7 +61,11 @@ CREATE TABLE IF NOT EXISTS lecturers (
 CREATE TABLE IF NOT EXISTS groups (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     tg_chat_id INTEGER UNIQUE NOT NULL,
-    title TEXT
+    title TEXT,
+    level_id INTEGER,
+    term_id INTEGER,
+    FOREIGN KEY (level_id) REFERENCES levels(id),
+    FOREIGN KEY (term_id) REFERENCES terms(id)
 );
 
 -- المواضيع داخل المجموعات


### PR DESCRIPTION
## Summary
- Create conversation handler for /insert_group allowing admins to set level and term for a chat
- Add group DB utilities and schema columns for level_id and term_id
- Register new group handler in bot startup

## Testing
- `pytest`
- `python -m py_compile bot/handlers/groups.py bot/db/groups.py bot/db/base.py bot/db/__init__.py bot/main.py bot/handlers/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa11d1014083299136fe018cbf86a7