### PR TITLE
Add hashtag parsing and material ingestion flow

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -36,7 +36,7 @@ async def insert_material(
     created_by_admin_id: int | None = None,
 ):
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
+        cur = await db.execute(
             """
             INSERT INTO materials (
                 subject_id, section, category, title, url, year_id, lecturer_id,
@@ -62,6 +62,7 @@ async def insert_material(
             ),
         )
         await db.commit()
+        return cur.lastrowid
 
 
 async def insert_year(name: str):

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -1,8 +1,22 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..db.ingestions import get_admin_id_by_tg_user, insert_ingestion
-from ..db.topics import is_admin
+from ..db.ingestions import (
+    get_admin_id_by_tg_user,
+    insert_ingestion,
+    attach_material,
+)
+from ..db.materials import (
+    ensure_year_id,
+    ensure_lecturer_id,
+    insert_material,
+)
+from ..db.topics import (
+    is_admin,
+    get_group_id_by_chat,
+    get_topic_link,
+)
+from ..parser.hashtags import parse_hashtags
 
 
 def _extract_hashtags(update: Update) -> list[str]:
@@ -32,7 +46,48 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         return
 
     message = update.effective_message
-    ingestion_id = await insert_ingestion(message.message_id, admin_id)
+    chat = update.effective_chat
+    thread_id = message.message_thread_id
+    if chat is None or thread_id is None:
+        return
+
+    group_id = await get_group_id_by_chat(chat.id)
+    if group_id is None:
+        return
+
+    topic_link = await get_topic_link(group_id, thread_id)
+    if topic_link is None:
+        return
+    subject_id, _, section = topic_link
+
+    info = parse_hashtags(tags)
+    category = info.get("category")
+    title = info.get("title")
+    if not category or not title:
+        return
+
+    year_id = None
+    if info.get("year"):
+        year_id = await ensure_year_id(info["year"])
+    lecturer_id = None
+    if info.get("lecturer"):
+        lecturer_id = await ensure_lecturer_id(info["lecturer"])
+
+    material_id = await insert_material(
+        subject_id,
+        section,
+        category,
+        title,
+        year_id=year_id,
+        lecturer_id=lecturer_id,
+        source_chat_id=chat.id,
+        source_topic_id=thread_id,
+        source_message_id=message.message_id,
+        created_by_admin_id=admin_id,
+    )
+
+    ingestion_id = await insert_ingestion(message.message_id, admin_id, "pending")
+    await attach_material(ingestion_id, material_id, "approved")
     await message.reply_text(f"✅ {ingestion_id}")
 
 

--- a/bot/parser/hashtags.py
+++ b/bot/parser/hashtags.py
@@ -1,0 +1,98 @@
+"""Utilities for parsing and normalizing hashtags.
+
+The ingestion flow relies on hashtags embedded in Telegram messages to
+extract metadata about the shared material.  This module provides helpers
+for normalizing the raw hashtag tokens and mapping them to the canonical
+categories used by the database.  Arabic synonyms for the supported
+categories are also recognised.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+def normalize_tag(tag: str) -> str:
+    """Return a simplified representation of a hashtag.
+
+    Leading ``#`` symbols are stripped, hyphens are converted to underscores
+    and the value is lower‑cased.
+    """
+
+    return tag.lstrip("#").replace("-", "_").strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# Category mapping
+# ---------------------------------------------------------------------------
+# Synonyms for the supported categories.  Both English and Arabic aliases are
+# included so that admins can use whichever language they prefer when tagging
+# materials.
+CATEGORY_ALIASES: dict[str, set[str]] = {
+    "lecture": {"lecture", "lectures", "محاضرة", "محاضرات"},
+    "slides": {"slides", "شرائح", "شريحة", "سلايد", "سلايدات"},
+    "audio": {"audio", "صوت", "صوتية", "صوتيات"},
+    "video": {"video", "فيديو", "فديو"},
+    "exam": {"exam", "اختبار", "اختبارات", "امتحان"},
+    "booklet": {"booklet", "مذكرة", "مذكرات"},
+    "summary": {"summary", "ملخص", "ملخصات"},
+    "notes": {"notes", "ملاحظات", "نوته"},
+}
+
+
+def resolve_category(tag: str) -> str | None:
+    """Map *tag* to a canonical category if possible."""
+
+    for category, aliases in CATEGORY_ALIASES.items():
+        if tag in aliases:
+            return category
+    return None
+
+
+_YEAR_RE = re.compile(r"^\d{4}(?:-\d{4})?$")
+
+
+def parse_hashtags(tags: Iterable[str]) -> dict[str, str | None]:
+    """Parse *tags* into structured information.
+
+    The function looks for known categories, year labels and lecturer names.
+    Remaining tags are combined and treated as the material title.
+    """
+
+    result: dict[str, str | None] = {
+        "year": None,
+        "lecturer": None,
+        "category": None,
+        "title": None,
+    }
+    leftovers: list[str] = []
+
+    for raw in tags:
+        norm = normalize_tag(raw)
+        if not norm:
+            continue
+
+        if result["category"] is None:
+            cat = resolve_category(norm)
+            if cat:
+                result["category"] = cat
+                continue
+
+        if result["year"] is None and _YEAR_RE.match(norm):
+            result["year"] = norm
+            continue
+
+        leftovers.append(norm)
+
+    if leftovers:
+        result["lecturer"] = leftovers.pop(0).replace("_", " ")
+        if leftovers:
+            result["title"] = " ".join(t.replace("_", " ") for t in leftovers)
+
+    return result
+
+
+__all__ = ["normalize_tag", "resolve_category", "parse_hashtags"]


### PR DESCRIPTION
## Summary
- add hashtag parser with Arabic category aliases
- parse hashtags during ingestion to create materials and link ingestions
- return created material id from database helper

## Testing
- `python -m py_compile bot/parser/hashtags.py bot/handlers/ingestion.py bot/db/materials.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa153627948329a88073671c09d4bb