### PR TITLE
Add level/term creation helpers

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -5,6 +5,8 @@ from .subjects import (
     get_term_id_by_name,
     insert_level,
     insert_term,
+    get_or_create_level,
+    get_or_create_term,
     insert_subject,
     get_terms_by_level,
     get_subjects_by_level_and_term,
@@ -59,7 +61,7 @@ from .ingestions import (
 __all__ = [
     'DB_PATH', 'init_db', 'migrate_if_needed',
     'get_levels', 'get_level_id_by_name', 'get_term_id_by_name',
-    'insert_level', 'insert_term', 'insert_subject',
+    'insert_level', 'insert_term', 'get_or_create_level', 'get_or_create_term', 'insert_subject',
     'get_terms_by_level', 'get_subjects_by_level_and_term', 'get_subject_id_by_name',
     'count_subjects', 'term_feature_flags', 'get_available_sections_for_subject',
     'get_year_id_by_name', 'get_lecturer_id_by_name', 'insert_material',

--- a/bot/db/subjects.py
+++ b/bot/db/subjects.py
@@ -39,6 +39,25 @@ async def insert_term(name: str):
         await db.commit()
 
 
+async def get_or_create_level(name: str) -> int:
+    level_id = await get_level_id_by_name(name)
+    if level_id is not None:
+        return level_id
+    await insert_level(name)
+    level_id = await get_level_id_by_name(name)
+    assert level_id is not None
+    return level_id
+
+
+async def get_or_create_term(name: str) -> int:
+    term_id = await get_term_id_by_name(name)
+    if term_id is not None:
+        return term_id
+    await insert_term(name)
+    term_id = await get_term_id_by_name(name)
+    assert term_id is not None
+    return term_id
+
 async def insert_subject(code: str, name: str, level_id: int, term_id: int):
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(

--- a/bot/handlers/groups.py
+++ b/bot/handlers/groups.py
@@ -16,8 +16,8 @@ from telegram.ext import (
 
 from bot.db import (
     is_admin,
-    get_level_id_by_name,
-    get_term_id_by_name,
+    get_or_create_level,
+    get_or_create_term,
     get_group_info,
     upsert_group,
 )
@@ -68,19 +68,13 @@ async def insert_group_received(update: Update, context: ContextTypes.DEFAULT_TY
     level_name = parts[0]
     term_name = parts[1] if len(parts) > 1 else None
 
-    level_id = await get_level_id_by_name(level_name)
-    if level_id is None:
-        await update.message.reply_text("المستوى غير معروف، حاول مرة أخرى.")
-        return ASK_INPUT
+    level_id = await get_or_create_level(level_name)
 
     if term_name is None:
         await update.message.reply_text("حدد الترم أيضًا.")
         return ASK_INPUT
 
-    term_id = await get_term_id_by_name(term_name)
-    if term_id is None:
-        await update.message.reply_text("الترم غير معروف، حاول مرة أخرى.")
-        return ASK_INPUT
+    term_id = await get_or_create_term(term_name)
 
     info.update(
         {


### PR DESCRIPTION
## Summary
- add get_or_create_level and get_or_create_term helpers
- allow group handler to create levels/terms on the fly and use their ids

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aa29d0cb3c832985393e876d9b1c72