### PR TITLE
Optimize group info retrieval

### DIFF
--- a/bot/db/topics.py
+++ b/bot/db/topics.py
@@ -22,13 +22,14 @@ async def is_admin(tg_user_id: int) -> bool:
     return tg_user_id in ADMIN_USER_IDS
 
 
-async def get_group_id_by_chat(tg_chat_id: int) -> int | None:
+async def get_group_id_by_chat(tg_chat_id: int) -> tuple[int, int, int] | None:
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
-            "SELECT id FROM groups WHERE tg_chat_id=?", (tg_chat_id,)
+            "SELECT id, level_id, term_id FROM groups WHERE tg_chat_id=?",
+            (tg_chat_id,),
         )
         row = await cur.fetchone()
-        return row[0] if row else None
+        return (row[0], row[1], row[2]) if row else None
 
 
 async def get_subject_by_name(name: str) -> tuple[int, str] | None:

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -54,9 +54,10 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     if chat is None or thread_id is None:
         return
 
-    group_id = await get_group_id_by_chat(chat.id)
-    if group_id is None:
+    group_info = await get_group_id_by_chat(chat.id)
+    if group_info is None:
         return
+    group_id, _, _ = group_info
 
     topic_link = await get_topic_link(group_id, thread_id)
     if topic_link is None:

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -17,7 +17,6 @@ from telegram.ext import (
 from bot.db import (
     is_admin,
     get_group_id_by_chat,
-    get_group_info,
     get_subject_by_name,
     get_topic_link,
     insert_subject,
@@ -57,16 +56,11 @@ async def insert_sub_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
         return ConversationHandler.END
 
-    group_id = await get_group_id_by_chat(chat.id)
-    if group_id is None:
-        await message.reply_text("المجموعة غير مسجلة. استخدم /insert_group أولًا.")
-        return ConversationHandler.END
-
-    group_info = await get_group_info(chat.id)
+    group_info = await get_group_id_by_chat(chat.id)
     if group_info is None:
         await message.reply_text("المجموعة غير مسجلة. استخدم /insert_group أولًا.")
         return ConversationHandler.END
-    level_id, term_id = group_info
+    group_id, level_id, term_id = group_info
     thread_id = message.message_thread_id
 
     context.user_data["insert_sub"] = {


### PR DESCRIPTION
## Summary
- fetch group id, level and term in a single database query
- reuse fetched group info in topic and ingestion handlers

## Testing
- `pytest -q`
- `python -m py_compile bot/db/topics.py bot/handlers/topics.py bot/handlers/ingestion.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa32a6822483298efad7da912d246b