### PR TITLE
Add admin management panel and permissions

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -40,7 +40,6 @@ from .materials import (
     list_categories_for_lecture,
 )
 from .topics import (
-    is_admin,
     get_group_id_by_chat,
     get_subject_by_name,
     get_topic_link,
@@ -50,10 +49,20 @@ from .groups import (
     get_group_info,
     upsert_group,
 )
-from .ingestions import (
+from .admins import (
+    MANAGE_GROUPS,
     UPLOAD_CONTENT,
+    PERMISSIONS,
+    list_admins,
+    get_admin,
+    add_admin,
+    update_admin,
+    remove_admin,
     get_admin_id_by_tg_user,
     get_admin_with_permissions,
+    is_admin,
+)
+from .ingestions import (
     insert_ingestion,
     attach_material,
     list_pending_ingestions,
@@ -78,9 +87,11 @@ __all__ = [
     'get_years_for_subject_section_lecturer', 'get_lecture_materials',
     'get_materials_by_category', 'list_categories_for_subject_section_year',
     'list_categories_for_lecture',
-    'is_admin', 'get_group_id_by_chat', 'get_subject_by_name', 'get_topic_link', 'upsert_topic',
+    'get_group_id_by_chat', 'get_subject_by_name', 'get_topic_link', 'upsert_topic',
     'get_group_info', 'upsert_group',
-    'UPLOAD_CONTENT', 'get_admin_id_by_tg_user', 'get_admin_with_permissions',
+    'MANAGE_GROUPS', 'UPLOAD_CONTENT', 'PERMISSIONS',
+    'list_admins', 'get_admin', 'add_admin', 'update_admin', 'remove_admin',
+    'get_admin_id_by_tg_user', 'get_admin_with_permissions', 'is_admin',
     'insert_ingestion', 'attach_material', 'list_pending_ingestions',
     'get_ingestion_material', 'update_ingestion_status', 'delete_ingestion',
     'delete_old_pending_ingestions',

--- a/bot/db/admins.py
+++ b/bot/db/admins.py
@@ -1,0 +1,131 @@
+import os
+
+import aiosqlite
+
+from bot.config import ADMIN_USER_IDS  # loads environment variables
+from .base import DB_PATH
+
+
+# Permission bit flags
+MANAGE_GROUPS = 1 << 0
+UPLOAD_CONTENT = 1 << 1
+
+PERMISSIONS = {
+    MANAGE_GROUPS: "إدارة المجموعات",
+    UPLOAD_CONTENT: "رفع المحتوى",
+}
+
+_owner = os.getenv("OWNER_TG_ID")
+OWNER_TG_ID = int(_owner) if _owner and _owner.strip().isdigit() else None
+
+
+async def list_admins() -> list[tuple[int, str, int, str]]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT tg_user_id, name, permissions_mask, level_scope FROM admins WHERE is_active=1"
+        )
+        return await cur.fetchall()
+
+
+async def get_admin(tg_user_id: int) -> tuple[int, str, int, str] | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT tg_user_id, name, permissions_mask, level_scope FROM admins WHERE tg_user_id=? AND is_active=1",
+            (tg_user_id,),
+        )
+        return await cur.fetchone()
+
+
+async def add_admin(
+    tg_user_id: int, name: str, permissions_mask: int, level_scope: str
+) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT INTO admins (tg_user_id, name, role, permissions_mask, level_scope, is_active)
+            VALUES (?, ?, 'ADMIN', ?, ?, 1)
+            ON CONFLICT(tg_user_id) DO UPDATE SET
+                name=excluded.name,
+                permissions_mask=excluded.permissions_mask,
+                level_scope=excluded.level_scope,
+                is_active=1
+            """,
+            (tg_user_id, name, permissions_mask, level_scope),
+        )
+        await db.commit()
+
+
+async def update_admin(
+    tg_user_id: int, name: str, permissions_mask: int, level_scope: str
+) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE admins SET name=?, permissions_mask=?, level_scope=? WHERE tg_user_id=?",
+            (name, permissions_mask, level_scope, tg_user_id),
+        )
+        await db.commit()
+
+
+async def remove_admin(tg_user_id: int) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("UPDATE admins SET is_active=0 WHERE tg_user_id=?", (tg_user_id,))
+        await db.commit()
+
+
+async def get_admin_with_permissions(tg_user_id: int) -> tuple[int, int] | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, permissions_mask FROM admins WHERE tg_user_id=? AND is_active=1",
+            (tg_user_id,),
+        )
+        row = await cur.fetchone()
+        return (row[0], row[1]) if row else None
+
+
+async def get_admin_id_by_tg_user(tg_user_id: int) -> int | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id FROM admins WHERE tg_user_id=? AND is_active=1",
+            (tg_user_id,),
+        )
+        row = await cur.fetchone()
+        return row[0] if row else None
+
+
+async def is_admin(
+    tg_user_id: int, permission: int | None = None, level_id: int | None = None
+) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT permissions_mask, level_scope, is_active FROM admins WHERE tg_user_id=?",
+            (tg_user_id,),
+        )
+        row = await cur.fetchone()
+
+    if row and row[2] == 1:
+        permissions, level_scope = row[0], row[1]
+        if permission and not (permissions & permission):
+            return False
+        if level_id is not None and level_scope not in ("all", str(level_id)):
+            return False
+        return True
+
+    if OWNER_TG_ID is not None and tg_user_id == OWNER_TG_ID:
+        return True
+    return tg_user_id in ADMIN_USER_IDS
+
+
+__all__ = [
+    "MANAGE_GROUPS",
+    "UPLOAD_CONTENT",
+    "PERMISSIONS",
+    "list_admins",
+    "get_admin",
+    "add_admin",
+    "update_admin",
+    "remove_admin",
+    "get_admin_with_permissions",
+    "get_admin_id_by_tg_user",
+    "is_admin",
+]
+

--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -45,6 +45,7 @@ async def _migrate(db: aiosqlite.Connection) -> None:
             name TEXT,
             role TEXT NOT NULL,
             permissions_mask INTEGER NOT NULL,
+            level_scope TEXT DEFAULT 'all',
             is_active INTEGER NOT NULL DEFAULT 1
         )
         """
@@ -52,6 +53,7 @@ async def _migrate(db: aiosqlite.Connection) -> None:
     admin_cols = [
         ("role", "TEXT", "'ADMIN'"),
         ("permissions_mask", "INTEGER", "0"),
+        ("level_scope", "TEXT", "'all'"),
         ("is_active", "INTEGER", "1"),
     ]
     for col, col_type, default in admin_cols:

--- a/bot/db/ingestions.py
+++ b/bot/db/ingestions.py
@@ -3,36 +3,6 @@ import aiosqlite
 from .base import DB_PATH
 
 
-# Permission bit flags
-UPLOAD_CONTENT = 1 << 0
-
-
-async def get_admin_with_permissions(tg_user_id: int) -> tuple[int, int] | None:
-    """Return admin id and permission mask for *tg_user_id*.
-
-    Only active admins are considered.  ``None`` is returned if the user is not
-    registered as an admin.
-    """
-
-    async with aiosqlite.connect(DB_PATH) as db:
-        cur = await db.execute(
-            "SELECT id, permissions_mask FROM admins WHERE tg_user_id=? AND is_active=1",
-            (tg_user_id,),
-        )
-        row = await cur.fetchone()
-        return (row[0], row[1]) if row else None
-
-
-async def get_admin_id_by_tg_user(tg_user_id: int) -> int | None:
-    async with aiosqlite.connect(DB_PATH) as db:
-        cur = await db.execute(
-            "SELECT id FROM admins WHERE tg_user_id=? AND is_active=1",
-            (tg_user_id,),
-        )
-        row = await cur.fetchone()
-        return row[0] if row else None
-
-
 async def insert_ingestion(
     tg_message_id: int, admin_id: int, status: str = "pending",
 ) -> int:
@@ -78,11 +48,7 @@ async def list_pending_ingestions() -> list[tuple[int, int, int]]:
 async def get_ingestion_material(
     ingestion_id: int,
 ) -> tuple[int, int, int] | None:
-    """Fetch material information linked to *ingestion_id*.
-
-    Returns a tuple of ``(material_id, source_chat_id, source_message_id)`` or
-    ``None`` if the ingestion does not exist.
-    """
+    """Fetch material information linked to *ingestion_id*."""
 
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
@@ -127,9 +93,6 @@ async def delete_old_pending_ingestions(hours: int = 24) -> int:
 
 
 __all__ = [
-    "UPLOAD_CONTENT",
-    "get_admin_id_by_tg_user",
-    "get_admin_with_permissions",
     "insert_ingestion",
     "attach_material",
     "list_pending_ingestions",

--- a/bot/db/topics.py
+++ b/bot/db/topics.py
@@ -1,25 +1,6 @@
-import os
-
 import aiosqlite
 
-from bot.config import ADMIN_USER_IDS  # loads environment variables
 from .base import DB_PATH
-
-_owner = os.getenv("OWNER_TG_ID")
-OWNER_TG_ID = int(_owner) if _owner and _owner.strip().isdigit() else None
-
-
-async def is_admin(tg_user_id: int) -> bool:
-    async with aiosqlite.connect(DB_PATH) as db:
-        cur = await db.execute(
-            "SELECT 1 FROM admins WHERE tg_user_id=? AND is_active=1", (tg_user_id,)
-        )
-        if (await cur.fetchone()) is not None:
-            return True
-
-    if OWNER_TG_ID is not None and tg_user_id == OWNER_TG_ID:
-        return True
-    return tg_user_id in ADMIN_USER_IDS
 
 
 async def get_group_id_by_chat(tg_chat_id: int) -> tuple[int, int, int] | None:
@@ -81,7 +62,6 @@ async def upsert_topic(
 
 
 __all__ = [
-    "is_admin",
     "get_group_id_by_chat",
     "get_subject_by_name",
     "get_topic_link",

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -5,6 +5,7 @@ from .groups import insert_group_conv
 from .ingestion import ingestion_handler
 from .approvals import approvals_handler, approval_callback
 from .moderation import moderation_handler
+from .admins import admins_conv
 
 __all__ = [
     "start",
@@ -16,4 +17,5 @@ __all__ = [
     "approvals_handler",
     "approval_callback",
     "moderation_handler",
+    "admins_conv",
 ]

--- a/bot/handlers/admins.py
+++ b/bot/handlers/admins.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import (
+    CommandHandler,
+    ConversationHandler,
+    CallbackQueryHandler,
+    MessageHandler,
+    ContextTypes,
+    filters,
+)
+
+from bot.db import (
+    is_admin,
+    MANAGE_GROUPS,
+    list_admins,
+    add_admin,
+    get_admin,
+    update_admin,
+    remove_admin,
+)
+from bot.keyboards import build_permissions_keyboard
+
+
+MENU, ADD_ID, ADD_NAME, ADD_PERMS, ADD_LEVEL, EDIT_ID, EDIT_NAME, EDIT_PERMS, EDIT_LEVEL, REMOVE_ID = range(10)
+
+
+async def admins_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    user = update.effective_user
+    if not user or not await is_admin(user.id, MANAGE_GROUPS):
+        await update.message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
+        return ConversationHandler.END
+
+    rows = await list_admins()
+    lines = ["المشرفون الحاليون:"]
+    for tg_id, name, _mask, _scope in rows:
+        lines.append(f"- {name or tg_id} ({tg_id})")
+    buttons = [
+        [InlineKeyboardButton("➕ إضافة", callback_data="adm_add")],
+        [InlineKeyboardButton("✏️ تعديل", callback_data="adm_edit")],
+        [InlineKeyboardButton("🗑️ إزالة", callback_data="adm_remove")],
+    ]
+    await update.message.reply_text(
+        "\n".join(lines), reply_markup=InlineKeyboardMarkup(buttons)
+    )
+    return MENU
+
+
+async def admins_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.answer()
+    data = query.data
+    if data == "adm_add":
+        await query.edit_message_text("أرسل معرف المستخدم (tg_user_id):")
+        return ADD_ID
+    if data == "adm_edit":
+        await query.edit_message_text("أرسل معرف المستخدم لتعديله:")
+        return EDIT_ID
+    if data == "adm_remove":
+        await query.edit_message_text("أرسل معرف المستخدم لإزالته:")
+        return REMOVE_ID
+    return ConversationHandler.END
+
+
+async def add_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        tg_id = int(update.message.text.strip())
+    except ValueError:
+        await update.message.reply_text("معرف غير صالح، حاول مرة أخرى.")
+        return ADD_ID
+    context.user_data["new_admin"] = {"tg_user_id": tg_id, "perm_mask": 0}
+    await update.message.reply_text("أرسل اسم المشرف:")
+    return ADD_NAME
+
+
+async def add_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    info = context.user_data["new_admin"]
+    info["name"] = update.message.text.strip()
+    kb = build_permissions_keyboard(info["perm_mask"])
+    await update.message.reply_text("اختر الصلاحيات:", reply_markup=kb)
+    return ADD_PERMS
+
+
+async def add_perms(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.answer()
+    info = context.user_data["new_admin"]
+    data = query.data
+    if data.startswith("perm_"):
+        flag = int(data.split("_", 1)[1])
+        info["perm_mask"] ^= flag
+        await query.edit_message_reply_markup(
+            build_permissions_keyboard(info["perm_mask"])
+        )
+        return ADD_PERMS
+    if data == "perm_done":
+        await query.edit_message_text("أرسل نطاق المستوى (مثال: all أو رقم المستوى):")
+        return ADD_LEVEL
+    return ConversationHandler.END
+
+
+async def add_level(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    info = context.user_data["new_admin"]
+    info["level_scope"] = update.message.text.strip()
+    await add_admin(
+        info["tg_user_id"],
+        info["name"],
+        info["perm_mask"],
+        info["level_scope"],
+    )
+    await update.message.reply_text("تم الحفظ.")
+    context.user_data.pop("new_admin", None)
+    return ConversationHandler.END
+
+
+async def edit_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        tg_id = int(update.message.text.strip())
+    except ValueError:
+        await update.message.reply_text("معرف غير صالح، حاول مرة أخرى.")
+        return EDIT_ID
+    row = await get_admin(tg_id)
+    if row is None:
+        await update.message.reply_text("المشرف غير موجود.")
+        return ConversationHandler.END
+    _tg, name, mask, scope = row
+    context.user_data["edit_admin"] = {
+        "tg_user_id": tg_id,
+        "name": name or "",
+        "perm_mask": mask,
+        "level_scope": scope,
+    }
+    await update.message.reply_text(f"الاسم الحالي: {name or ''}\nأرسل الاسم الجديد:")
+    return EDIT_NAME
+
+
+async def edit_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    info = context.user_data["edit_admin"]
+    info["name"] = update.message.text.strip()
+    kb = build_permissions_keyboard(info["perm_mask"])
+    await update.message.reply_text("حدّث الصلاحيات:", reply_markup=kb)
+    return EDIT_PERMS
+
+
+async def edit_perms(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.answer()
+    info = context.user_data["edit_admin"]
+    data = query.data
+    if data.startswith("perm_"):
+        flag = int(data.split("_", 1)[1])
+        info["perm_mask"] ^= flag
+        await query.edit_message_reply_markup(
+            build_permissions_keyboard(info["perm_mask"])
+        )
+        return EDIT_PERMS
+    if data == "perm_done":
+        await query.edit_message_text(
+            f"النطاق الحالي: {info['level_scope']}\nأرسل النطاق الجديد:"
+        )
+        return EDIT_LEVEL
+    return ConversationHandler.END
+
+
+async def edit_level(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    info = context.user_data["edit_admin"]
+    info["level_scope"] = update.message.text.strip()
+    await update_admin(
+        info["tg_user_id"],
+        info["name"],
+        info["perm_mask"],
+        info["level_scope"],
+    )
+    await update.message.reply_text("تم التحديث.")
+    context.user_data.pop("edit_admin", None)
+    return ConversationHandler.END
+
+
+async def remove_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        tg_id = int(update.message.text.strip())
+    except ValueError:
+        await update.message.reply_text("معرف غير صالح، حاول مرة أخرى.")
+        return REMOVE_ID
+    await remove_admin(tg_id)
+    await update.message.reply_text("تمت الإزالة.")
+    return ConversationHandler.END
+
+
+admins_conv = ConversationHandler(
+    entry_points=[CommandHandler("admins", admins_start)],
+    states={
+        MENU: [CallbackQueryHandler(admins_menu, pattern="^adm_")],
+        ADD_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_id)],
+        ADD_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_name)],
+        ADD_PERMS: [CallbackQueryHandler(add_perms, pattern="^perm_")],
+        ADD_LEVEL: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_level)],
+        EDIT_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, edit_id)],
+        EDIT_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, edit_name)],
+        EDIT_PERMS: [CallbackQueryHandler(edit_perms, pattern="^perm_")],
+        EDIT_LEVEL: [MessageHandler(filters.TEXT & ~filters.COMMAND, edit_level)],
+        REMOVE_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, remove_id)],
+    },
+    fallbacks=[],
+)
+
+
+__all__ = ["admins_conv"]
+

--- a/bot/handlers/approvals.py
+++ b/bot/handlers/approvals.py
@@ -4,8 +4,9 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes
 
 from ..config import ARCHIVE_CHANNEL_ID
-from ..db.topics import is_admin
-from ..db.ingestions import (
+from ..db import (
+    is_admin,
+    UPLOAD_CONTENT,
     list_pending_ingestions,
     get_ingestion_material,
     update_ingestion_status,
@@ -14,7 +15,7 @@ from ..db.materials import update_material_storage
 
 async def list_pending(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user = update.effective_user
-    if not user or not await is_admin(user.id):
+    if not user or not await is_admin(user.id, UPLOAD_CONTENT):
         return
     pending = await list_pending_ingestions()
     if not pending:
@@ -37,7 +38,7 @@ async def handle_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     query = update.callback_query
     await query.answer()
     user = update.effective_user
-    if not user or not await is_admin(user.id):
+    if not user or not await is_admin(user.id, UPLOAD_CONTENT):
         await query.edit_message_reply_markup(reply_markup=None)
         return
     action, ing_id = query.data.split(":")

--- a/bot/handlers/groups.py
+++ b/bot/handlers/groups.py
@@ -16,6 +16,7 @@ from telegram.ext import (
 
 from bot.db import (
     is_admin,
+    MANAGE_GROUPS,
     get_or_create_level,
     get_or_create_term,
     get_group_info,
@@ -30,7 +31,7 @@ async def insert_group_start(update: Update, context: ContextTypes.DEFAULT_TYPE)
     user = update.effective_user
     chat = update.effective_chat
 
-    if not await is_admin(user.id):
+    if not await is_admin(user.id, MANAGE_GROUPS):
         await message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
         return ConversationHandler.END
 

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -1,7 +1,7 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..db.ingestions import (
+from ..db import (
     UPLOAD_CONTENT,
     get_admin_with_permissions,
     insert_ingestion,
@@ -12,7 +12,7 @@ from ..db.materials import (
     ensure_lecturer_id,
     insert_material,
 )
-from ..db.topics import (
+from ..db import (
     get_group_id_by_chat,
     get_topic_link,
 )

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -16,6 +16,7 @@ from telegram.ext import (
 
 from bot.db import (
     is_admin,
+    MANAGE_GROUPS,
     get_group_id_by_chat,
     get_subject_by_name,
     get_topic_link,
@@ -52,7 +53,7 @@ async def insert_sub_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await message.reply_text("استخدم هذا الأمر داخل موضوع ضمن مجموعة.")
         return ConversationHandler.END
 
-    if not await is_admin(user.id):
+    if not await is_admin(user.id, MANAGE_GROUPS):
         await message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
         return ConversationHandler.END
 

--- a/bot/keyboards/__init__.py
+++ b/bot/keyboards/__init__.py
@@ -1,7 +1,9 @@
 from .constants import *  # noqa: F401,F403
 from .builders import *  # noqa: F401,F403
+from .admins import *  # noqa: F401,F403
 
 from .constants import __all__ as _constants_all
 from .builders import __all__ as _builders_all
+from .admins import __all__ as _admins_all
 
-__all__ = [*_constants_all, *_builders_all]
+__all__ = [*_constants_all, *_builders_all, *_admins_all]

--- a/bot/keyboards/admins.py
+++ b/bot/keyboards/admins.py
@@ -1,0 +1,16 @@
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from bot.db.admins import PERMISSIONS
+
+
+def build_permissions_keyboard(mask: int) -> InlineKeyboardMarkup:
+    buttons = []
+    for flag, label in PERMISSIONS.items():
+        prefix = "✅" if mask & flag else "❌"
+        buttons.append([InlineKeyboardButton(f"{prefix} {label}", callback_data=f"perm_{flag}")])
+    buttons.append([InlineKeyboardButton("تم", callback_data="perm_done")])
+    return InlineKeyboardMarkup(buttons)
+
+
+__all__ = ["build_permissions_keyboard"]
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -20,6 +20,7 @@ from .handlers import (
     insert_sub_conv,
     ingestion_handler,
     insert_group_conv,
+    admins_conv,
     approvals_handler,
     approval_callback,
     moderation_handler,
@@ -56,6 +57,7 @@ def main():
     app = ApplicationBuilder().token(BOT_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
     app.add_handler(insert_group_conv)
+    app.add_handler(admins_conv)
     app.add_handler(insert_sub_conv)
     app.add_handler(approvals_handler)
     app.add_handler(approval_callback)

--- a/database/init.sql
+++ b/database/init.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS lecturers (
      name TEXT,
      role TEXT NOT NULL,
      permissions_mask INTEGER NOT NULL,
+     level_scope TEXT DEFAULT 'all',
      is_active INTEGER NOT NULL DEFAULT 1
  );
 


### PR DESCRIPTION
## Summary
- add level-scope and permission management for admins
- provide `/admins` command with interactive CRUD panel
- enforce permission checks across handlers

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aa3c18b8c48329943936a3ba207e9a