### PR TITLE
Restrict insert commands to supergroups

### DIFF
--- a/bot/handlers/groups.py
+++ b/bot/handlers/groups.py
@@ -31,6 +31,10 @@ async def insert_group_start(update: Update, context: ContextTypes.DEFAULT_TYPE)
     user = update.effective_user
     chat = update.effective_chat
 
+    if chat.type != "supergroup":
+        await message.reply_text("استخدم هذا الأمر داخل مجموعة خارقة.")
+        return ConversationHandler.END
+
     if not await is_admin(user.id, MANAGE_GROUPS):
         await message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
         return ConversationHandler.END
@@ -150,7 +154,7 @@ async def insert_group_confirm(update: Update, context: ContextTypes.DEFAULT_TYP
 
 
 insert_group_conv = ConversationHandler(
-    entry_points=[CommandHandler("insert_group", insert_group_start)],
+    entry_points=[CommandHandler("insert_group", insert_group_start, filters.ChatType.GROUPS)],
     states={
         ASK_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, insert_group_received)],
         CONFIRM: [CallbackQueryHandler(insert_group_confirm, pattern="^ingrp_")],

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -49,6 +49,10 @@ async def insert_sub_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
     chat = update.effective_chat
 
+    if chat.type != "supergroup":
+        await message.reply_text("استخدم هذا الأمر داخل مجموعة خارقة.")
+        return ConversationHandler.END
+
     if not message or message.message_thread_id is None:
         await message.reply_text("استخدم هذا الأمر داخل موضوع ضمن مجموعة.")
         return ConversationHandler.END
@@ -247,7 +251,7 @@ async def insert_sub_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 
 insert_sub_conv = ConversationHandler(
-    entry_points=[CommandHandler("insert_sub", insert_sub_start)],
+    entry_points=[CommandHandler("insert_sub", insert_sub_start, filters.ChatType.GROUPS)],
     states={
         ASK_INPUT: [
             MessageHandler(filters.TEXT & ~filters.COMMAND, insert_sub_received)


### PR DESCRIPTION
## Summary
- limit insert_group and insert_sub commands to group chats
- ensure handlers only proceed in supergroup chats

## Testing
- `python -m py_compile bot/handlers/groups.py bot/handlers/topics.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68aa42fd97ec8329944b13c411c79def