### PR TITLE
feat: expand hashtag parsing

### DIFF
--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -65,17 +65,22 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     subject_id, _, section = topic_link
 
     info = parse_hashtags(tags)
-    category = info.get("category")
-    title = info.get("title")
-    if not category or not title:
+    category = info["category"]
+    title = info["title"]
+    lecturer_name = info["lecturer"]
+
+    # ``board_images`` is one of the supported categories and relies on the
+    # extracted title (either from ``category:title`` syntax or remaining
+    # hashtags) to identify the lecture it belongs to.
+    if category is None or title is None:
         return
 
     year_id = None
-    if info.get("year"):
+    if info["year"]:
         year_id = await ensure_year_id(info["year"])
     lecturer_id = None
-    if info.get("lecturer"):
-        lecturer_id = await ensure_lecturer_id(info["lecturer"])
+    if lecturer_name:
+        lecturer_id = await ensure_lecturer_id(lecturer_name)
 
     material_id = await insert_material(
         subject_id,

--- a/bot/parser/hashtags.py
+++ b/bot/parser/hashtags.py
@@ -40,6 +40,13 @@ CATEGORY_ALIASES: dict[str, set[str]] = {
     "booklet": {"booklet", "مذكرة", "مذكرات"},
     "summary": {"summary", "ملخص", "ملخصات"},
     "notes": {"notes", "ملاحظات", "نوته"},
+    "board_images": {"صور_السبورة", "board", "board_images"},
+    "related": {"ملف_ذو_صلة", "related"},
+    # Additional categories supported by the database
+    "external_link": {"external_link"},
+    "simulation": {"simulation"},
+    "mind_map": {"mind_map"},
+    "transcript": {"transcript"},
 }
 
 
@@ -53,6 +60,17 @@ def resolve_category(tag: str) -> str | None:
 
 
 _YEAR_RE = re.compile(r"^\d{4}(?:-\d{4})?$")
+
+LECTURER_PREFIXES: tuple[str, ...] = (
+    "الدكتور_",
+    "الدكتورة_",
+    "الأستاذ_",
+    "الأستاذة_",
+    "م_",
+    "م",
+    "مهندس_",
+    "مهندسة_",
+)
 
 
 def parse_hashtags(tags: Iterable[str]) -> dict[str, str | None]:
@@ -75,6 +93,12 @@ def parse_hashtags(tags: Iterable[str]) -> dict[str, str | None]:
         if not norm:
             continue
 
+        # Support ``category:title`` syntax
+        if ":" in norm:
+            norm, title = norm.split(":", 1)
+            if not result["title"]:
+                result["title"] = title.replace("_", " ")
+
         if result["category"] is None:
             cat = resolve_category(norm)
             if cat:
@@ -85,12 +109,20 @@ def parse_hashtags(tags: Iterable[str]) -> dict[str, str | None]:
             result["year"] = norm
             continue
 
-        leftovers.append(norm)
+        if result["lecturer"] is None:
+            for prefix in LECTURER_PREFIXES:
+                if norm.startswith(prefix):
+                    name = norm[len(prefix) :].replace("_", " ").strip()
+                    if name:
+                        result["lecturer"] = name
+                        break
+            else:
+                leftovers.append(norm)
+        else:
+            leftovers.append(norm)
 
-    if leftovers:
-        result["lecturer"] = leftovers.pop(0).replace("_", " ")
-        if leftovers:
-            result["title"] = " ".join(t.replace("_", " ") for t in leftovers)
+    if leftovers and not result["title"]:
+        result["title"] = " ".join(t.replace("_", " ") for t in leftovers)
 
     return result
 


### PR DESCRIPTION
## Summary
- expand category aliases for board images, related files and other types
- capture titles from `category:title` hashtags and detect lecturer prefixes
- use parsed category, title and lecturer when ingesting materials

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa43edc9a083298cb8a989b122ccee