### PR TITLE
feat: dynamic main menu with admin management

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -52,6 +52,7 @@ from .groups import (
 from .admins import (
     MANAGE_GROUPS,
     UPLOAD_CONTENT,
+    MANAGE_ADMINS,
     PERMISSIONS,
     list_admins,
     get_admin,
@@ -89,7 +90,7 @@ __all__ = [
     'list_categories_for_lecture',
     'get_group_id_by_chat', 'get_subject_by_name', 'get_topic_link', 'upsert_topic',
     'get_group_info', 'upsert_group',
-    'MANAGE_GROUPS', 'UPLOAD_CONTENT', 'PERMISSIONS',
+    'MANAGE_GROUPS', 'UPLOAD_CONTENT', 'MANAGE_ADMINS', 'PERMISSIONS',
     'list_admins', 'get_admin', 'add_admin', 'update_admin', 'remove_admin',
     'get_admin_id_by_tg_user', 'get_admin_with_permissions', 'is_admin',
     'insert_ingestion', 'attach_material', 'list_pending_ingestions',

--- a/bot/db/admins.py
+++ b/bot/db/admins.py
@@ -9,10 +9,12 @@ from .base import DB_PATH
 # Permission bit flags
 MANAGE_GROUPS = 1 << 0
 UPLOAD_CONTENT = 1 << 1
+MANAGE_ADMINS = 1 << 2
 
 PERMISSIONS = {
     MANAGE_GROUPS: "إدارة المجموعات",
     UPLOAD_CONTENT: "رفع المحتوى",
+    MANAGE_ADMINS: "إدارة المشرفين",
 }
 
 # Mask representing full access to all permissions
@@ -130,6 +132,7 @@ async def is_admin(
 __all__ = [
     "MANAGE_GROUPS",
     "UPLOAD_CONTENT",
+    "MANAGE_ADMINS",
     "FULL_ACCESS",
     "PERMISSIONS",
     "list_admins",

--- a/bot/handlers/admins.py
+++ b/bot/handlers/admins.py
@@ -12,7 +12,7 @@ from telegram.ext import (
 
 from bot.db import (
     is_admin,
-    MANAGE_GROUPS,
+    MANAGE_ADMINS,
     list_admins,
     add_admin,
     get_admin,
@@ -27,7 +27,7 @@ MENU, ADD_ID, ADD_NAME, ADD_PERMS, ADD_LEVEL, EDIT_ID, EDIT_NAME, EDIT_PERMS, ED
 
 async def admins_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
-    if not user or not await is_admin(user.id, MANAGE_GROUPS):
+    if not user or not await is_admin(user.id, MANAGE_ADMINS):
         await update.message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
         return ConversationHandler.END
 
@@ -188,7 +188,10 @@ async def remove_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 admins_conv = ConversationHandler(
-    entry_points=[CommandHandler("admins", admins_start)],
+    entry_points=[
+        CommandHandler("admins", admins_start),
+        MessageHandler(filters.Regex("^👤 إدارة المشرفين$"), admins_start),
+    ],
     states={
         MENU: [CallbackQueryHandler(admins_menu, pattern="^adm_")],
         ADD_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_id)],

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -23,7 +23,6 @@ from bot.db import (
 )
 
 from ..keyboards.constants import (
-    main_menu,
     TERM_MENU_SHOW_SUBJECTS,
     TERM_MENU_PLAN,
     TERM_MENU_LINKS,
@@ -53,6 +52,7 @@ from ..keyboards.builders import (
     generate_lecture_titles_keyboard,
     generate_year_category_menu_keyboard,
     generate_lecture_category_menu_keyboard,
+    generate_main_menu,
 )
 
 from ..navigation import NavigationState
@@ -65,7 +65,10 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # لا شيء محدد → القائمة الرئيسية
     if not stack:
-        return await update.message.reply_text("اختر من القائمة:", reply_markup=main_menu)
+        return await update.message.reply_text(
+            "اختر من القائمة:",
+            reply_markup=await generate_main_menu(update.effective_user.id),
+        )
 
     top_type = stack[-1][0]
 
@@ -196,7 +199,10 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         msg = f"المحاضرة: {lecture_title}\nاختر نوع الملف:" if cats else "لا توجد أنواع ملفات لهذه المحاضرة."
         return await update.message.reply_text(msg, reply_markup=generate_lecture_category_menu_keyboard(cats))
 
-    return await update.message.reply_text("اختر من القائمة:", reply_markup=main_menu)
+    return await update.message.reply_text(
+        "اختر من القائمة:",
+        reply_markup=await generate_main_menu(update.effective_user.id),
+    )
 
 # --------------------------------------------------------------------------
 async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -230,7 +236,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # 2) زر العودة إلى الرئيسية
     if text == "🔙 العودة للقائمة الرئيسية":
         nav.back_to_levels()
-        return await update.message.reply_text("تم الرجوع إلى القائمة الرئيسية ⬇️", reply_markup=main_menu)
+        return await update.message.reply_text(
+            "تم الرجوع إلى القائمة الرئيسية ⬇️",
+            reply_markup=await generate_main_menu(update.effective_user.id),
+        )
 
     # # 3) زر الرجوع الذكي (خطوة واحدة)
     # if text == "🔙 العودة":
@@ -288,7 +297,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if text in (TERM_MENU_SHOW_SUBJECTS, TERM_MENU_PLAN, TERM_MENU_LINKS, TERM_MENU_ADV_SEARCH):
         level_id, term_id = nav.get_ids()
         if not (level_id and term_id):
-            return await update.message.reply_text("ابدأ باختيار المستوى ثم الترم.", reply_markup=main_menu)
+            return await update.message.reply_text(
+                "ابدأ باختيار المستوى ثم الترم.",
+                reply_markup=await generate_main_menu(update.effective_user.id),
+            )
 
         if text == TERM_MENU_SHOW_SUBJECTS:
             nav.push_view("subject_list")
@@ -348,7 +360,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         subject_id = nav.data.get("subject_id")
         section_code = nav.data.get("section")
         if not (subject_id and section_code):
-            return await update.message.reply_text("ابدأ باختيار المادة ثم القسم.", reply_markup=main_menu)
+            return await update.message.reply_text(
+                "ابدأ باختيار المادة ثم القسم.",
+                reply_markup=await generate_main_menu(update.effective_user.id),
+            )
 
         if text == FILTER_BY_YEAR:
             years = await get_years_for_subject_section(subject_id, section_code)
@@ -427,7 +442,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         lecturer_label = next((lbl for t, lbl in nav.stack if t == "lecturer"), "")
 
         if not (subject_id and section_code and lecturer_id):
-            return await update.message.reply_text("ابدأ باختيار المادة → القسم → المحاضر.", reply_markup=main_menu)
+            return await update.message.reply_text(
+                "ابدأ باختيار المادة → القسم → المحاضر.",
+                reply_markup=await generate_main_menu(update.effective_user.id),
+            )
 
         if text == CHOOSE_YEAR_FOR_LECTURER:
             years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -1,7 +1,7 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..keyboards.constants import main_menu
+from ..keyboards.builders import generate_main_menu
 from ..navigation import NavigationState
 
 
@@ -9,5 +9,5 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     NavigationState(context.user_data).back_to_levels()
     await update.message.reply_text(
         "👋 مرحبًا بك في بوت أرشيف قسم الميكاترونكس.\nاختر من القائمة:",
-        reply_markup=main_menu,
+        reply_markup=await generate_main_menu(update.effective_user.id),
     )

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -19,6 +19,21 @@ from .constants import (
 )
 
 
+async def generate_main_menu(user_id: int) -> ReplyKeyboardMarkup:
+    """Build the main menu, appending admin controls if permitted."""
+    from bot.db import is_admin, MANAGE_ADMINS
+
+    buttons = [
+        ["📚 المستويات", "🗂 الخطة الدراسية"],
+        ["🔧 البرامج الهندسية", " بحث"],
+        ["📡 القنوات والمجموعات", "🆘 مساعدة"],
+        ["📨 تواصل معنا"],
+    ]
+    if await is_admin(user_id, MANAGE_ADMINS):
+        buttons.append(["👤 إدارة المشرفين"])
+    return ReplyKeyboardMarkup(buttons, resize_keyboard=True, one_time_keyboard=True)
+
+
 def _rows(items: list[str], cols: int = 2) -> list[list[str]]:
     """Split items into rows with a fixed number of columns, skipping empties."""
     items = [i for i in items if i]
@@ -188,6 +203,7 @@ def generate_lecture_category_menu_keyboard(categories: list[str]) -> ReplyKeybo
 
 
 __all__ = [
+    "generate_main_menu",
     "generate_levels_keyboard",
     "generate_terms_keyboard",
     "generate_subjects_keyboard",


### PR DESCRIPTION
## Summary
- generate main menu dynamically with optional admin controls
- call dynamic main menu from start and navigation handlers
- add MANAGE_ADMINS permission and route admin management button to /admins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4573427483298bbeede946778dc1