### PR TITLE
Add separate approve content permission

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -52,6 +52,7 @@ from .groups import (
 from .admins import (
     MANAGE_GROUPS,
     UPLOAD_CONTENT,
+    APPROVE_CONTENT,
     PERMISSIONS,
     list_admins,
     get_admin,
@@ -89,7 +90,7 @@ __all__ = [
     'list_categories_for_lecture',
     'get_group_id_by_chat', 'get_subject_by_name', 'get_topic_link', 'upsert_topic',
     'get_group_info', 'upsert_group',
-    'MANAGE_GROUPS', 'UPLOAD_CONTENT', 'PERMISSIONS',
+    'MANAGE_GROUPS', 'UPLOAD_CONTENT', 'APPROVE_CONTENT', 'PERMISSIONS',
     'list_admins', 'get_admin', 'add_admin', 'update_admin', 'remove_admin',
     'get_admin_id_by_tg_user', 'get_admin_with_permissions', 'is_admin',
     'insert_ingestion', 'attach_material', 'list_pending_ingestions',

--- a/bot/db/admins.py
+++ b/bot/db/admins.py
@@ -9,10 +9,12 @@ from .base import DB_PATH
 # Permission bit flags
 MANAGE_GROUPS = 1 << 0
 UPLOAD_CONTENT = 1 << 1
+APPROVE_CONTENT = 1 << 2
 
 PERMISSIONS = {
     MANAGE_GROUPS: "إدارة المجموعات",
     UPLOAD_CONTENT: "رفع المحتوى",
+    APPROVE_CONTENT: "مصادقة المحتوى",
 }
 
 # Mask representing full access to all permissions
@@ -130,6 +132,7 @@ async def is_admin(
 __all__ = [
     "MANAGE_GROUPS",
     "UPLOAD_CONTENT",
+    "APPROVE_CONTENT",
     "FULL_ACCESS",
     "PERMISSIONS",
     "list_admins",

--- a/bot/handlers/approvals.py
+++ b/bot/handlers/approvals.py
@@ -6,7 +6,7 @@ from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes
 from ..config import ARCHIVE_CHANNEL_ID
 from ..db import (
     is_admin,
-    UPLOAD_CONTENT,
+    APPROVE_CONTENT,
     list_pending_ingestions,
     get_ingestion_material,
     update_ingestion_status,
@@ -15,7 +15,7 @@ from ..db.materials import update_material_storage
 
 async def list_pending(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user = update.effective_user
-    if not user or not await is_admin(user.id, UPLOAD_CONTENT):
+    if not user or not await is_admin(user.id, APPROVE_CONTENT):
         return
     pending = await list_pending_ingestions()
     if not pending:
@@ -39,7 +39,7 @@ async def handle_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     query = update.callback_query
     await query.answer()
     user = update.effective_user
-    if not user or not await is_admin(user.id, UPLOAD_CONTENT):
+    if not user or not await is_admin(user.id, APPROVE_CONTENT):
         await query.edit_message_reply_markup(reply_markup=None)
         return
     action, ing_id = query.data.split(":")

--- a/bot/keyboards/admins.py
+++ b/bot/keyboards/admins.py
@@ -4,6 +4,7 @@ from bot.db.admins import PERMISSIONS
 
 
 def build_permissions_keyboard(mask: int) -> InlineKeyboardMarkup:
+    """Create an inline keyboard to toggle available admin permissions."""
     buttons = []
     for flag, label in PERMISSIONS.items():
         prefix = "✅" if mask & flag else "❌"


### PR DESCRIPTION
## Summary
- add new APPROVE_CONTENT permission bit and description
- require APPROVE_CONTENT to access approval commands
- document admin permissions keyboard to toggle all permissions

## Testing
- `pytest`
- `python -m py_compile bot/db/admins.py bot/db/__init__.py bot/handlers/approvals.py bot/keyboards/admins.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa4ee1e8148329b0d979c1f41bceab