### PR TITLE
core: تثبيت ربط الهاندلرز ومنع ردود المجموعات

### DIFF
--- a/bot/handlers/admins.py
+++ b/bot/handlers/admins.py
@@ -12,7 +12,7 @@ from telegram.ext import (
 
 from bot.db import (
     is_admin,
-    MANAGE_GROUPS,
+    MANAGE_ADMINS,
     list_admins,
     add_admin,
     get_admin,
@@ -27,7 +27,7 @@ MENU, ADD_ID, ADD_NAME, ADD_PERMS, ADD_LEVEL, EDIT_ID, EDIT_NAME, EDIT_PERMS, ED
 
 async def admins_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
-    if not user or not await is_admin(user.id, MANAGE_GROUPS):
+    if not user or not await is_admin(user.id, MANAGE_ADMINS):
         await update.message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
         return ConversationHandler.END
 
@@ -188,7 +188,7 @@ async def remove_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 admins_conv = ConversationHandler(
-    entry_points=[CommandHandler("admins", admins_start)],
+    entry_points=[CommandHandler("admins", admins_start, filters.ChatType.PRIVATE)],
     states={
         MENU: [CallbackQueryHandler(admins_menu, pattern="^adm_")],
         ADD_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_id)],

--- a/bot/handlers/approvals.py
+++ b/bot/handlers/approvals.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
-from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes
+from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes, filters
 
 from ..config import ARCHIVE_CHANNEL_ID
 from ..db import (
@@ -16,6 +16,7 @@ from ..db.materials import update_material_storage
 async def list_pending(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user = update.effective_user
     if not user or not await is_admin(user.id, APPROVE_CONTENT):
+        await update.message.reply_text("عذرًا، لا تملك صلاحية هذا الأمر.")
         return
     pending = await list_pending_ingestions()
     if not pending:
@@ -72,7 +73,9 @@ async def handle_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await query.edit_message_reply_markup(reply_markup=None)
 
 
-approvals_handler = CommandHandler("approvals", list_pending)
+approvals_handler = CommandHandler(
+    "approvals", list_pending, filters.ChatType.PRIVATE
+)
 approval_callback = CallbackQueryHandler(handle_decision, pattern="^(appr|rej):")
 
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -58,12 +58,18 @@ def main():
     loop.run_until_complete(ensure_owner_full_perms(OWNER_TG_ID))
 
     app = ApplicationBuilder().token(BOT_TOKEN).build()
-    app.add_handler(CommandHandler("start", start))
-    app.add_handler(insert_group_conv)
+
+    # أوامر خاصة
+    app.add_handler(CommandHandler("start", start, filters.ChatType.PRIVATE))
     app.add_handler(CommandHandler("insert_group", insert_group_private, filters.ChatType.PRIVATE))
-    app.add_handler(admins_conv)
-    app.add_handler(insert_sub_conv)
     app.add_handler(CommandHandler("insert_sub", insert_sub_private, filters.ChatType.PRIVATE))
+
+    # أوامر المجموعات
+    app.add_handler(insert_group_conv)
+    app.add_handler(insert_sub_conv)
+
+    # أوامر المشرفين
+    app.add_handler(admins_conv)
     app.add_handler(approvals_handler)
     app.add_handler(approval_callback)
     app.add_handler(
@@ -93,7 +99,19 @@ def main():
 
     app.job_queue.run_daily(purge_temp_archives, time=time(hour=0, minute=0))
 
-    print("✅ Bot is running...")
+    print(
+        "\n".join(
+            [
+                "📟 bot wiring:",
+                "  /start -> private",
+                "  /insert_group -> groups",
+                "  /insert_sub -> groups",
+                "  /approvals -> private",
+                "  /admins -> private",
+                "  unknown-text -> private only",
+            ]
+        )
+    )
     app.run_polling()
 
 


### PR DESCRIPTION
## ملخص
- قصر أوامر /start و/approvals و/admins على الخاص، وربط /insert_group و/insert_sub بالمجموعات فقط
- إضافة لافتة تشخيصية لبيان أوضاع الهاندلرز عند تشغيل البوت
- إرجاع رسالة صلاحية عند محاولة غير المصرح له الوصول إلى /approvals أو /admins

## اختبار
- `python -m py_compile bot/main.py bot/handlers/admins.py bot/handlers/approvals.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab7602689c8329ac91c0eb90640404