### PR TITLE
إضافة استخراج يدوي للسنة الهجرية في الوسوم

### DIFF
--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -1,8 +1,8 @@
-from telegram import Update
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
 import logging
+import re
 
 from ..config import OWNER_TG_ID
 from ..db import (
@@ -14,28 +14,25 @@ from ..db import (
     get_topic_link,
 )
 from ..db.materials import ensure_year_id, ensure_lecturer_id, insert_material
-from ..parser.hashtags import parse_hashtags
+from ..parser.hashtags import parse_hashtags, extract_hijri_year
 
 
 logger = logging.getLogger(__name__)
 
+HASHTAG_RE = re.compile(r"#\S+")
 
-def _extract_hashtags(update: Update) -> list[str]:
-    msg = update.message
-    if not msg:
-        return []
-    text = msg.text or msg.caption or ""
-    entities = msg.entities or msg.caption_entities or []
-    tags = []
-    for ent in entities:
-        if ent.type == "hashtag":
-            tags.append(text[ent.offset : ent.offset + ent.length])
-    return tags
+
+def _extract_hashtags(text: str) -> list[str]:
+    return HASHTAG_RE.findall(text)
 
 
 async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     message = update.effective_message
-    tags = _extract_hashtags(update)
+    text = message.caption or message.text or ""
+    year = extract_hijri_year(text)
+    tags = _extract_hashtags(text)
+    if year is not None:
+        tags = [t for t in tags if extract_hijri_year(t) is None]
     if not tags:
         logger.warning("No hashtags found")
         if message:
@@ -90,15 +87,11 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     category = info["category"]
     title = info["title"]
     lecturer_name = info["lecturer"]
-    year = info["year"]
-    if year and (not year.isdigit() or len(year) != 4):
-        await message.reply_text("السنة الهجرية غير صحيحة.")
-        return
     if category is None or title is None:
         await message.reply_text("الوسوم تفتقد الفئة أو العنوان.")
         return
 
-    year_id = await ensure_year_id(year) if year else None
+    year_id = await ensure_year_id(str(year)) if year else None
     lecturer_id = await ensure_lecturer_id(lecturer_name) if lecturer_name else None
 
     material_id = await insert_material(

--- a/bot/parser/hashtags.py
+++ b/bot/parser/hashtags.py
@@ -11,6 +11,25 @@ from __future__ import annotations
 import re
 from typing import Iterable
 
+BIDI_RE = re.compile(r"[\u200e\u200f\u202a-\u202e]")
+_ARABIC_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+HIJRI_RE = re.compile(r"(?<!\w)#\s*([0-9]{4}|[٠-٩]{4})\s*(?:هـ|ه)?\b")
+
+
+def normalize_digits(s: str) -> str:
+    return s.translate(_ARABIC_DIGITS)
+
+
+def extract_hijri_year(text: str) -> int | None:
+    if not text:
+        return None
+    cleaned = BIDI_RE.sub("", text)
+    m = HIJRI_RE.search(cleaned)
+    if not m:
+        return None
+    y = int(normalize_digits(m.group(1)))
+    return y if 1300 <= y <= 1600 else None
+
 # ---------------------------------------------------------------------------
 # Normalisation helpers
 # ---------------------------------------------------------------------------
@@ -130,4 +149,9 @@ def parse_hashtags(tags: Iterable[str]) -> dict[str, str | None]:
     return result
 
 
-__all__ = ["normalize_tag", "resolve_category", "parse_hashtags"]
+__all__ = [
+    "normalize_tag",
+    "resolve_category",
+    "parse_hashtags",
+    "extract_hijri_year",
+]


### PR DESCRIPTION
## Summary
- دعم استخراج السنة الهجرية بتحليل نصي مباشر وإزالة محارف الاتجاه مع تطبيع الأرقام
- استخدام regex لاستخراج الوسوم يدويًا وتمرير السنة في ملخص الاعتماد عند رفع المواد

## Testing
- `pytest -q`
- `python -m py_compile bot/parser/hashtags.py bot/handlers/ingestion.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7af67bdc832982170673826f2095