### PR TITLE
Restrict unknown option replies to private chats

### DIFF
--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -200,6 +200,10 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 # --------------------------------------------------------------------------
 async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    chat = update.effective_chat
+    if not chat or chat.type != "private":
+        return
+
     text = update.message.text if update.message else ""
     nav = NavigationState(context.user_data)
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -79,13 +79,7 @@ def main():
     app.add_handler(
         MessageHandler(
             filters.ChatType.GROUPS
-            & (
-                filters.Document.ALL
-                | filters.PHOTO
-                | filters.VIDEO
-                | filters.AUDIO
-                | filters.TEXT
-            )
+            & (filters.Regex("#") | filters.CaptionRegex("#"))
             & ~filters.COMMAND,
             ingestion_handler,
         ),
@@ -108,6 +102,7 @@ def main():
                 "  /insert_sub -> groups",
                 "  /approvals -> private",
                 "  /admins -> private",
+                "  ingestion (#) -> groups",
                 "  unknown-text -> private only",
             ]
         )


### PR DESCRIPTION
## Summary
- avoid triggering ingestion handler on group messages without hashtags
- guard unknown-text handler to private chats only
- document handler scopes on startup

## Testing
- `python -m py_compile bot/main.py bot/handlers/navigation.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab7c4fa9c88329830f0da12cc1b001