### PR TITLE
دعم وسوم عربية مرتبة وموارد الترم

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -41,6 +41,9 @@ from .materials import (
     list_categories_for_subject_section_year,
     list_categories_for_lecture,
 )
+from .years import get_or_create as get_or_create_year
+from .lecturers import get_or_create as get_or_create_lecturer
+from .term_resources import insert_term_resource, get_latest_term_resource
 from .topics import (
     get_group_id_by_chat,
     get_binding,
@@ -93,6 +96,8 @@ __all__ = [
     'get_years_for_subject_section_lecturer', 'get_lecture_materials',
     'get_materials_by_category', 'list_categories_for_subject_section_year',
     'list_categories_for_lecture',
+    'get_or_create_year', 'get_or_create_lecturer',
+    'insert_term_resource', 'get_latest_term_resource',
     'get_group_id_by_chat', 'get_binding', 'bind',
     'get_group_info', 'upsert_group',
     'MANAGE_GROUPS', 'UPLOAD_CONTENT', 'APPROVE_CONTENT', 'MANAGE_ADMINS', 'PERMISSIONS',

--- a/bot/db/lecturers.py
+++ b/bot/db/lecturers.py
@@ -1,0 +1,23 @@
+import aiosqlite
+
+from .base import DB_PATH
+
+
+async def get_or_create(name: str, role: str = "lecturer") -> int:
+    """Return id for lecturer *name*, inserting if necessary."""
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute("SELECT id FROM lecturers WHERE name=?", (name,))
+        row = await cur.fetchone()
+        if row:
+            return row[0]
+        cur = await db.execute(
+            "INSERT INTO lecturers (name, role) VALUES (?, ?)",
+            (name, role),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+__all__ = ["get_or_create"]
+

--- a/bot/db/term_resources.py
+++ b/bot/db/term_resources.py
@@ -1,0 +1,39 @@
+import aiosqlite
+
+from .base import DB_PATH
+
+
+async def insert_term_resource(
+    term_id: int,
+    kind: str,
+    storage_chat_id: int,
+    storage_msg_id: int,
+):
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            """
+            INSERT INTO term_resources (term_id, kind, tg_storage_chat_id, tg_storage_msg_id)
+            VALUES (?, ?, ?, ?)
+            """,
+            (term_id, kind, storage_chat_id, storage_msg_id),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_latest_term_resource(term_id: int, kind: str):
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            """
+            SELECT tg_storage_chat_id, tg_storage_msg_id
+            FROM term_resources
+            WHERE term_id=? AND kind=?
+            ORDER BY id DESC LIMIT 1
+            """,
+            (term_id, kind),
+        )
+        return await cur.fetchone()
+
+
+__all__ = ["insert_term_resource", "get_latest_term_resource"]
+

--- a/bot/db/years.py
+++ b/bot/db/years.py
@@ -1,0 +1,20 @@
+import aiosqlite
+
+from .base import DB_PATH
+
+
+async def get_or_create(name: str) -> int:
+    """Return id for *name*, inserting a new year if needed."""
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute("SELECT id FROM years WHERE name=?", (name,))
+        row = await cur.fetchone()
+        if row:
+            return row[0]
+        cur = await db.execute("INSERT INTO years (name) VALUES (?)", (name,))
+        await db.commit()
+        return cur.lastrowid
+
+
+__all__ = ["get_or_create"]
+

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -2,7 +2,6 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes, CallbackQueryHandler
 
 import logging
-import re
 import asyncio
 
 from ..config import OWNER_TG_ID
@@ -13,37 +12,29 @@ from ..db import (
     attach_material,
     get_group_id_by_chat,
     get_binding,
+    get_or_create_year,
+    get_or_create_lecturer,
+    insert_term_resource,
 )
-from ..db.materials import (
-    ensure_year_id,
-    ensure_lecturer_id,
-    insert_material,
-    find_exact,
-)
-from ..parser.hashtags import parse_hashtags, extract_hijri_year
+from ..db.materials import insert_material, find_exact
+from ..parser.hashtags import parse_hashtags
 
 
 logger = logging.getLogger(__name__)
-
-HASHTAG_RE = re.compile(r"#\S+")
-
-
-def _extract_hashtags(text: str) -> list[str]:
-    return HASHTAG_RE.findall(text)
 
 
 async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     message = update.effective_message
     text = message.caption or message.text or ""
-    year = extract_hijri_year(text)
-    tags = _extract_hashtags(text)
-    if year is not None:
-        tags = [t for t in tags if extract_hijri_year(t) is None]
-    if not tags:
-        logger.warning("No hashtags found")
-        if message:
-            await message.reply_text("لم يتم العثور على وسوم.")
+    info, error = parse_hashtags(text)
+    if error:
+        await message.reply_text(error)
         return
+
+    year = info.year
+    category = info.content_type
+    title = info.title or ""
+    lecturer_name = info.lecturer
 
     user = update.effective_user
     if not user:
@@ -65,10 +56,10 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
 
     chat = update.effective_chat
     thread_id = message.message_thread_id if message else None
-    if chat is None or thread_id is None:
-        logger.warning("Missing chat %s or thread %s", chat, thread_id)
+    if chat is None:
+        logger.warning("Missing chat %s", chat)
         if message:
-            await message.reply_text("لا يمكن تحديد المحادثة أو الموضوع.")
+            await message.reply_text("لا يمكن تحديد المحادثة.")
         return
 
     group_info = await get_group_id_by_chat(chat.id)
@@ -77,28 +68,40 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         logger.warning("Group info not found for chat %s", chat.id)
         await message.reply_text("المجموعة غير معروفة.")
         return
-    binding = await get_binding(chat.id, thread_id)
-    logger.debug("binding=%s", binding)
-    if binding is None:
-        logger.warning(
-            "Topic link not found for chat %s thread %s", chat.id, thread_id
-        )
-        await message.reply_text("لم يتم العثور على رابط الموضوع.")
-        return
-    subject_id = binding["subject_id"]
-    section = binding["section"]
-    subject_name = binding["subject_name"]
+    binding = None
+    if category != "attendance":
+        if thread_id is None:
+            await message.reply_text(
+                "هذا النوع يتطلب ربط الـTopic بمادة/قسم عبر /insert_sub."
+            )
+            return
+        binding = await get_binding(chat.id, thread_id)
+        logger.debug("binding=%s", binding)
+        if binding is None:
+            await message.reply_text(
+                "هذا النوع يتطلب ربط الـTopic بمادة/قسم عبر /insert_sub."
+            )
+            return
+        subject_id = binding["subject_id"]
+        section = binding["section"]
+        subject_name = binding["subject_name"]
+    else:
+        subject_id = section = subject_name = None
 
-    info = parse_hashtags(tags)
-    category = info["category"]
-    title = info["title"]
-    lecturer_name = info["lecturer"]
-    if category is None or title is None:
-        await message.reply_text("الوسوم تفتقد الفئة أو العنوان.")
+    if category is None:
+        await message.reply_text("لم يتم التعرف على نوع المحتوى.")
         return
 
-    year_id = await ensure_year_id(str(year)) if year else None
-    lecturer_id = await ensure_lecturer_id(lecturer_name) if lecturer_name else None
+    if category == "attendance":
+        term_id = group_info[2]
+        await insert_term_resource(term_id, "attendance", chat.id, message.message_id)
+        await message.reply_text("✅ تم الاستلام.")
+        return
+
+    year_id = await get_or_create_year(str(year)) if year else None
+    lecturer_id = (
+        await get_or_create_lecturer(lecturer_name) if lecturer_name else None
+    )
 
     existing = await find_exact(
         subject_id,

--- a/bot/parser/hashtags.py
+++ b/bot/parser/hashtags.py
@@ -1,157 +1,233 @@
-"""Utilities for parsing and normalizing hashtags.
+"""Parsing utilities for hashtag based ingestion.
 
-The ingestion flow relies on hashtags embedded in Telegram messages to
-extract metadata about the shared material.  This module provides helpers
-for normalizing the raw hashtag tokens and mapping them to the canonical
-categories used by the database.  Arabic synonyms for the supported
-categories are also recognised.
+The new ingestion flow relies solely on plain text contained in the caption
+or message body.  ``telegram`` entities are intentionally ignored so the
+parsing logic here works with raw text only.  The helpers normalise hidden
+direction markers, convert Eastern Arabic digits to their Latin
+representation and then extract structured information from the ordered list
+of hashtags.
+
+The parser understands a small, fixed set of Arabic hashtags that indicate
+the *content type* in addition to generic tags for the lecture number, year
+and lecturer name.  The order of these tags is significant and is validated
+according to the rules described in :mod:`README`.
 """
+
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
-from typing import Iterable
+from typing import Iterable, List, Tuple
 
-BIDI_RE = re.compile(r"[\u200e\u200f\u202a-\u202e]")
-_ARABIC_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
-HIJRI_RE = re.compile(r"(?<!\w)#\s*([0-9]{4}|[٠-٩]{4})\s*(?:هـ|ه)?\b")
-
-
-def normalize_digits(s: str) -> str:
-    return s.translate(_ARABIC_DIGITS)
-
-
-def extract_hijri_year(text: str) -> int | None:
-    if not text:
-        return None
-    cleaned = BIDI_RE.sub("", text)
-    m = HIJRI_RE.search(cleaned)
-    if not m:
-        return None
-    y = int(normalize_digits(m.group(1)))
-    return y if 1300 <= y <= 1600 else None
+from ..utils.formatting import arabic_ordinal, to_display_name, ARABIC_ORDINALS
 
 # ---------------------------------------------------------------------------
 # Normalisation helpers
 # ---------------------------------------------------------------------------
+BIDI_RE = re.compile(r"[\u200e\u200f\u202a-\u202e]")
+_ARABIC_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
 
-def normalize_tag(tag: str) -> str:
-    """Return a simplified representation of a hashtag.
 
-    The helper removes any leading ``#`` markers, replaces hyphens with
-    underscores and folds the text to lower‑case.  Extra whitespace around the
-    tag is stripped so the result can be safely compared against our known
-    aliases.
-    """
+def _clean(text: str) -> str:
+    """Return *text* without direction markers and with normalised digits."""
 
-    cleaned = tag.lstrip("#").replace("-", "_").strip()
-    return cleaned.casefold()
+    return BIDI_RE.sub("", text).translate(_ARABIC_DIGITS)
 
 
 # ---------------------------------------------------------------------------
-# Category mapping
+# Tag extraction
 # ---------------------------------------------------------------------------
-# Synonyms for the supported categories.  Both English and Arabic aliases are
-# included so that admins can use whichever language they prefer when tagging
-# materials.
-CATEGORY_ALIASES: dict[str, set[str]] = {
-    "lecture": {"lecture", "lectures", "محاضرة", "محاضرات"},
-    "slides": {"slides", "شرائح", "شريحة", "سلايد", "سلايدات"},
-    "audio": {"audio", "صوت", "صوتية", "صوتيات"},
-    "video": {"video", "فيديو", "فديو"},
-    "exam": {"exam", "اختبار", "اختبارات", "امتحان"},
-    "booklet": {"booklet", "مذكرة", "مذكرات"},
-    "summary": {"summary", "ملخص", "ملخصات"},
-    "notes": {"notes", "note", "ملاحظات", "نوته"},
-    "board_images": {"صور_السبورة", "board", "board_images"},
-    "related": {"ملف_ذو_صلة", "related"},
-    # Additional categories supported by the database
-    "external_link": {"external_link"},
-    "simulation": {"simulation"},
-    "mind_map": {"mind_map"},
-    "transcript": {"transcript"},
+
+CONTENT_TYPE_ALIASES = {
+    "موجز_يومي": "daily_brief",
+    "صور_السبورة": "board_images",
+    "الملزمة": "booklet",
+    "نموذج_النصفي": "exam_mid",
+    "نموذج_النهائي": "exam_final",
+    "التوصيف": "syllabus",
+    "جدول_الحضور": "attendance",
+    # Existing types kept for backwards compatibility
+    "slides": "slides",
+    "audio": "audio",
+    "video": "video",
+    "board_images": "board_images",
 }
 
-
-def resolve_category(tag: str) -> str | None:
-    """Map *tag* to a canonical category if possible."""
-
-    return next(
-        (category for category, aliases in CATEGORY_ALIASES.items() if tag in aliases),
-        None,
-    )
-
-
-_YEAR_RE = re.compile(r"^\d{4}(?:-\d{4})?$")
-
-LECTURER_PREFIXES: tuple[str, ...] = (
+LECTURER_PREFIXES: Tuple[str, ...] = (
     "الدكتور_",
     "الدكتورة_",
     "الأستاذ_",
     "الأستاذة_",
+    "المهندس_",
+    "المهندسة_",
     "م_",
     "م",
-    "مهندس_",
-    "مهندسة_",
 )
 
+ORDINAL_WORDS = {v: k for k, v in ARABIC_ORDINALS.items()}
 
-def parse_hashtags(tags: Iterable[str]) -> dict[str, str | None]:
-    """Parse *tags* into structured information.
 
-    The function looks for known categories, year labels and lecturer names.
-    Remaining tags are combined and treated as the material title.
+@dataclass
+class ParsedHashtags:
+    content_type: str | None = None
+    lecture_no: int | None = None
+    lecture_no_display: str | None = None
+    title: str | None = None
+    year: int | None = None
+    lecturer: str | None = None
+    tags: List[str] | None = None
+
+
+# Regular expressions
+YEAR_TAG_RE = re.compile(r"^#(\d{4})(?:هـ|ه)?$")
+LECTURE_TAG_RE = re.compile(r"^#(?:ال)?محاضرة_(.+?)(?::\s*(.+))?$")
+
+
+def _split_lines(text: str) -> List[str]:
+    """Return ordered list of hashtag lines from *text*.
+
+    Only lines starting with ``#`` are considered hashtags.  Trailing text
+    after ``:`` is preserved so titles can be extracted for lecture tags.
     """
 
-    result: dict[str, str | None] = {
-        "year": None,
-        "lecturer": None,
-        "category": None,
-        "title": None,
-    }
-    leftovers: list[str] = []
+    lines = []
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("#"):
+            lines.append(s)
+    return lines
+
+
+def parse_hashtags(text: str) -> Tuple[ParsedHashtags, str | None]:
+    """Parse *text* and return ``(info, error)``.
+
+    ``error`` is ``None`` when parsing and validation succeed.  Otherwise it
+    contains a short Arabic message suitable for presenting to the user.
+    """
+
+    cleaned = _clean(text or "")
+    tags = _split_lines(cleaned)
+    info = ParsedHashtags(tags=tags)
+    sequence: List[str] = []
 
     for raw in tags:
-        norm = normalize_tag(raw)
-        if not norm:
+        token = raw.split()[0]
+
+        # Content type
+        ct = CONTENT_TYPE_ALIASES.get(token.lstrip("#"))
+        if ct and info.content_type is None:
+            info.content_type = ct
+            sequence.append("content")
             continue
 
-        # Support ``category:title`` syntax
-        if ":" in norm:
-            norm, title = norm.split(":", 1)
-            if not result["title"]:
-                result["title"] = title.replace("_", " ")
-
-        if result["category"] is None:
-            cat = resolve_category(norm)
-            if cat:
-                result["category"] = cat
+        # Year
+        m = YEAR_TAG_RE.match(token)
+        if m and info.year is None:
+            y = int(m.group(1))
+            if 1300 <= y <= 1600:
+                info.year = y
+                sequence.append("year")
                 continue
 
-        if result["year"] is None and _YEAR_RE.match(norm):
-            result["year"] = norm
-            continue
-
-        if result["lecturer"] is None:
-            for prefix in LECTURER_PREFIXES:
-                if norm.startswith(prefix):
-                    name = norm[len(prefix) :].replace("_", " ").strip()
-                    if name:
-                        result["lecturer"] = name
-                        break
+        # Lecturer
+        if info.lecturer is None:
+            norm = token.lstrip("#")
+            for p in LECTURER_PREFIXES:
+                if norm.startswith(p):
+                    info.lecturer = to_display_name(norm[len(p):])
+                    sequence.append("lecturer")
+                    break
             else:
-                leftovers.append(norm)
+                # Lecture tag?
+                m = LECTURE_TAG_RE.match(raw)
+                if m and info.lecture_no is None:
+                    ident, title = m.groups()
+                    ident = ident.strip()
+                    if ident.isdigit():
+                        info.lecture_no = int(ident)
+                    else:
+                        info.lecture_no = ORDINAL_WORDS.get(ident)
+                    if info.lecture_no:
+                        info.lecture_no_display = arabic_ordinal(info.lecture_no)
+                    if title:
+                        info.title = title.strip()
+                    sequence.append("lecture")
+                else:
+                    sequence.append("unknown")
         else:
-            leftovers.append(norm)
+            # Lecture tag after lecturer?
+            m = LECTURE_TAG_RE.match(raw)
+            if m and info.lecture_no is None:
+                ident, title = m.groups()
+                ident = ident.strip()
+                if ident.isdigit():
+                    info.lecture_no = int(ident)
+                else:
+                    info.lecture_no = ORDINAL_WORDS.get(ident)
+                if info.lecture_no:
+                    info.lecture_no_display = arabic_ordinal(info.lecture_no)
+                if title:
+                    info.title = title.strip()
+                sequence.append("lecture")
+            else:
+                sequence.append("unknown")
 
-    if leftovers and not result["title"]:
-        result["title"] = " ".join(t.replace("_", " ") for t in leftovers)
+    # ------------------------------------------------------------------
+    # Validation of order and required tags
+    # ------------------------------------------------------------------
+    def _err(msg: str) -> Tuple[ParsedHashtags, str]:
+        return info, msg
 
-    return result
+    ct = info.content_type
+    if ct in {"daily_brief", "board_images"}:
+        expected = ["content", "lecture", "year"]
+        if sequence[:3] != expected:
+            return _err(
+                "رجاءً اتّبع ترتيب الوسوم لهذا النوع: #موجز_يومي\n#المحاضرة_1: العنوان\n#1446"
+            )
+        if len(sequence) > 4 or (len(sequence) == 4 and sequence[3] != "lecturer"):
+            return _err(
+                "رجاءً اتّبع ترتيب الوسوم لهذا النوع: #موجز_يومي\n#المحاضرة_1: العنوان\n#1446\n#الدكتور_اسم (اختياري)"
+            )
+        if not info.lecture_no or not info.title:
+            return _err("هذا النوع يتطلب وسم محاضرة بصيغة: #المحاضرة_1: <العنوان>")
+
+    elif ct in {"booklet", "exam_mid", "exam_final"}:
+        expected = ["content", "year"]
+        if sequence[:2] != expected:
+            return _err(
+                "رجاءً اتّبع ترتيب الوسوم لهذا النوع: #الملزمة\n#1446"
+            )
+        if len(sequence) > 3 or (len(sequence) == 3 and sequence[2] != "lecturer"):
+            return _err(
+                "رجاءً اتّبع ترتيب الوسوم لهذا النوع: #الملزمة\n#1446\n#الدكتور_اسم (اختياري)"
+            )
+
+    elif ct == "syllabus":
+        if not sequence or sequence[0] != "content":
+            return _err("رجاءً اتّبع ترتيب الوسوم لهذا النوع: #التوصيف")
+        if any(s not in {"content", "year", "lecturer"} for s in sequence):
+            return _err("رجاءً اتّبع ترتيب الوسوم لهذا النوع: #التوصيف")
+        if sequence.count("year") and sequence.index("year") != 1:
+            return _err("رجاءً اتّبع ترتيب الوسوم لهذا النوع: #التوصيف\n#1446 (اختياري)")
+        if sequence.count("lecturer"):
+            idx = sequence.index("lecturer")
+            if idx not in {1, 2}:
+                return _err(
+                    "رجاءً اتّبع ترتيب الوسوم لهذا النوع: #التوصيف\n#1446\n#الدكتور_اسم"
+                )
+
+    elif ct == "attendance":
+        if sequence != ["content"]:
+            return _err("رجاءً اتّبع ترتيب الوسوم لهذا النوع: #جدول_الحضور")
+
+    # Types that require lecture tag but have no strict ordering
+    if ct in {"slides", "audio", "video", "board_images"}:
+        if not info.lecture_no:
+            return _err("هذا النوع يتطلب وسم محاضرة بصيغة: #المحاضرة_1: <العنوان>")
+
+    return info, None
 
 
-__all__ = [
-    "normalize_tag",
-    "resolve_category",
-    "parse_hashtags",
-    "extract_hijri_year",
-]
+__all__ = ["parse_hashtags", "ParsedHashtags"]
+

--- a/database/init.sql
+++ b/database/init.sql
@@ -160,3 +160,17 @@ ON materials(lecturer_id);
 
 CREATE INDEX IF NOT EXISTS idx_materials_admin
 ON materials(created_by_admin_id);
+
+-- موارد مرتبطة بالترم (مثل جدول الحضور)
+CREATE TABLE IF NOT EXISTS term_resources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    term_id INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    tg_storage_chat_id INTEGER NOT NULL,
+    tg_storage_msg_id INTEGER NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (term_id) REFERENCES terms(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_term_resources_term_kind
+ON term_resources(term_id, kind);


### PR DESCRIPTION
## Summary
- إضافة محلل وسوم عربية يدوي مع التحقق من ترتيب الوسوم ومتطلبات كل نوع
- توسيع إدخال المحتوى لدعم أنواع مثل #موجز_يومي و#جدول_الحضور وتخزينها في جدول term_resources
- تجهيز وحدات قاعدة البيانات للسنوات والمحاضرين وموارد الترم

## Testing
- `python -m py_compile bot/parser/hashtags.py bot/db/years.py bot/db/lecturers.py bot/db/term_resources.py bot/db/__init__.py bot/handlers/ingestion.py`
- `python -m py_compile bot/db/lecturers.py bot/db/term_resources.py bot/db/years.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab897b8c7c83299e46e2e3ea3ed50f