### PR TITLE
fix(approvals/replace): persist file_unique_id to avoid MessageId crash

### DIFF
--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -31,6 +31,7 @@ async def _migrate(db: aiosqlite.Connection) -> None:
         ("source_topic_id", "INTEGER"),
         ("source_message_id", "INTEGER"),
         ("created_by_admin_id", "INTEGER"),
+        ("file_unique_id", "TEXT"),
     ]
     for col, col_type in materials_cols:
         if not await _column_exists(db, "materials", col):
@@ -112,7 +113,12 @@ async def _migrate(db: aiosqlite.Connection) -> None:
         """
     )
 
-    ingestion_cols = [("tg_message_id", "INTEGER"), ("admin_id", "INTEGER")]
+    ingestion_cols = [
+        ("tg_message_id", "INTEGER"),
+        ("admin_id", "INTEGER"),
+        ("action", "TEXT DEFAULT 'add'"),
+        ("file_unique_id", "TEXT"),
+    ]
     for col, col_type in ingestion_cols:
         if not await _column_exists(db, "ingestions", col):
             await db.execute(f"ALTER TABLE ingestions ADD COLUMN {col} {col_type}")

--- a/bot/db/ingestions.py
+++ b/bot/db/ingestions.py
@@ -8,14 +8,17 @@ async def insert_ingestion(
     admin_id: int,
     status: str = "pending",
     action: str = "add",
+    file_unique_id: str | None = None,
 ) -> int:
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
             """
-            INSERT INTO ingestions (tg_message_id, admin_id, status, action)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO ingestions (
+                tg_message_id, admin_id, status, action, file_unique_id
+            )
+            VALUES (?, ?, ?, ?, ?)
             """,
-            (tg_message_id, admin_id, status, action),
+            (tg_message_id, admin_id, status, action, file_unique_id),
         )
         await db.commit()
         return cur.lastrowid
@@ -50,14 +53,14 @@ async def list_pending_ingestions() -> list[tuple[int, int, int, str]]:
 
 async def get_ingestion_material(
     ingestion_id: int,
-) -> tuple[int, int, int, int, str, int | None, int | None] | None:
+) -> tuple[int, int, int, int, str, str | None, int | None, int | None] | None:
     """Fetch material and ingestion details for *ingestion_id*."""
 
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
             """
             SELECT m.id, m.source_chat_id, m.source_message_id,
-                   i.tg_message_id, i.action,
+                   i.tg_message_id, i.action, i.file_unique_id,
                    m.tg_storage_chat_id, m.tg_storage_msg_id
             FROM ingestions i
             JOIN materials m ON m.id = i.material_id
@@ -74,6 +77,7 @@ async def get_ingestion_material(
             row[4],
             row[5],
             row[6],
+            row[7],
         ) if row else None
 
 

--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -4,6 +4,16 @@ import re
 from .base import DB_PATH
 
 
+async def ensure_file_unique_id_column() -> None:
+    """Ensure the ``file_unique_id`` column exists on ``materials`` table."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute("PRAGMA table_info(materials)")
+        cols = [row[1] for row in await cur.fetchall()]
+        if "file_unique_id" not in cols:
+            await db.execute("ALTER TABLE materials ADD COLUMN file_unique_id TEXT")
+            await db.commit()
+
+
 # -----------------------------------------------------------------------------
 # Helpers for years/lecturers
 # -----------------------------------------------------------------------------

--- a/bot/handlers/approvals.py
+++ b/bot/handlers/approvals.py
@@ -13,21 +13,12 @@ from ..db import (
     update_ingestion_status,
 )
 from ..db.materials import update_material_storage
+from ..utils.telegram import (
+    get_file_unique_id_from_message as _get_file_unique_id_from_message,  # noqa: F401
+)
 
 
 logger = logging.getLogger("bot.approvals")
-
-
-def _get_file_unique_id(msg) -> str | None:
-    if msg.document:
-        return msg.document.file_unique_id
-    if msg.audio:
-        return msg.audio.file_unique_id
-    if msg.video:
-        return msg.video.file_unique_id
-    if msg.photo:
-        return msg.photo[-1].file_unique_id
-    return None
 
 async def list_pending(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user = update.effective_user
@@ -72,6 +63,7 @@ async def handle_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         src_msg_id,
         new_msg_id,
         action_type,
+        file_unique_id,
         storage_chat_id,
         storage_msg_id,
     ) = info
@@ -82,10 +74,15 @@ async def handle_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 from_chat_id=src_chat_id,
                 message_id=new_msg_id,
             )
-            file_id = _get_file_unique_id(copied)
             await update_material_storage(
-                material_id, ARCHIVE_CHANNEL_ID, copied.message_id, file_id
+                material_id, ARCHIVE_CHANNEL_ID, copied.message_id, file_unique_id
             )
+            if file_unique_id:
+                logger.debug(
+                    "replace #%s used file_unique_id", ingestion_id
+                )
+            else:
+                logger.debug("replace #%s without file_unique_id", ingestion_id)
             if storage_chat_id and storage_msg_id:
                 try:
                     await context.bot.delete_message(
@@ -108,9 +105,8 @@ async def handle_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 from_chat_id=src_chat_id,
                 message_id=src_msg_id,
             )
-            file_id = _get_file_unique_id(copied)
             await update_material_storage(
-                material_id, ARCHIVE_CHANNEL_ID, copied.message_id, file_id
+                material_id, ARCHIVE_CHANNEL_ID, copied.message_id, file_unique_id
             )
             await update_ingestion_status(ingestion_id, "approved")
             await context.bot.send_message(

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -17,7 +17,7 @@ from ..db import (
 )
 from ..db.materials import insert_material, find_exact
 from ..parser.hashtags import parse_hashtags
-from ..utils.telegram import send_ephemeral
+from ..utils.telegram import send_ephemeral, get_file_unique_id_from_message
 
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     message = update.effective_message
+    file_unique_id = get_file_unique_id_from_message(message)
     text = message.caption or message.text or ""
     info, error = parse_hashtags(text)
     if error:
@@ -125,6 +126,7 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             "year_id": year_id,
             "lecturer_id": lecturer_id,
             "lecturer_name": lecturer_name,
+            "file_unique_id": file_unique_id,
         }
         buttons = [
             [
@@ -150,14 +152,16 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         title,
         year_id=year_id,
         lecturer_id=lecturer_id,
-        file_unique_id=None,
+        file_unique_id=file_unique_id,
         source_chat_id=chat.id,
         source_topic_id=thread_id,
         source_message_id=message.message_id,
         created_by_admin_id=admin_id,
     )
 
-    ingestion_id = await insert_ingestion(message.message_id, admin_id)
+    ingestion_id = await insert_ingestion(
+        message.message_id, admin_id, file_unique_id=file_unique_id
+    )
     await attach_material(ingestion_id, material_id, "pending")
     await message.reply_text(
         f"✅ تم الاستلام. رقم العملية: #{ingestion_id}\nسيتم إشعارك بعد المراجعة."
@@ -211,7 +215,9 @@ async def handle_duplicate_decision(
         return
     old_material_id = data["old_material_id"]
     admin_id = data["admin_id"]
-    ingestion_id = await insert_ingestion(msg_id, admin_id, action="replace")
+    ingestion_id = await insert_ingestion(
+        msg_id, admin_id, action="replace", file_unique_id=data.get("file_unique_id")
+    )
     await attach_material(ingestion_id, old_material_id, "pending")
     await context.bot.send_message(
         chat_id=data["chat_id"],

--- a/bot/utils/telegram.py
+++ b/bot/utils/telegram.py
@@ -1,4 +1,5 @@
 import logging
+from telegram import Message
 from telegram.ext import ContextTypes
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,29 @@ def build_archive_link(archive_chat_id: int, message_id: int, username: str | No
     return f"https://t.me/c/{internal_id}/{message_id}"
 
 
+def get_file_unique_id_from_message(msg: Message | None) -> str | None:
+    """Extract ``file_unique_id`` from *msg* if present.
+
+    The helper gracefully handles ``None`` and different media types supported by
+    Telegram. ``None`` is returned when no file-based media is found.
+    """
+    if not msg:
+        return None
+    if msg.document:
+        return msg.document.file_unique_id
+    if msg.photo:
+        return msg.photo[-1].file_unique_id
+    if msg.video:
+        return msg.video.file_unique_id
+    if msg.audio:
+        return msg.audio.file_unique_id
+    if msg.voice:
+        return msg.voice.file_unique_id
+    if msg.animation:
+        return msg.animation.file_unique_id
+    return None
+
+
 async def send_ephemeral(
     context: ContextTypes.DEFAULT_TYPE,
     chat_id: int,
@@ -39,4 +63,8 @@ async def send_ephemeral(
     return msg
 
 
-__all__ = ["build_archive_link", "send_ephemeral"]
+__all__ = [
+    "build_archive_link",
+    "send_ephemeral",
+    "get_file_unique_id_from_message",
+]

--- a/database/init.sql
+++ b/database/init.sql
@@ -110,6 +110,7 @@ CREATE TABLE IF NOT EXISTS ingestions (
     tg_message_id INTEGER,
     admin_id INTEGER,
     action TEXT NOT NULL DEFAULT 'add',
+    file_unique_id TEXT,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (material_id) REFERENCES materials(id),
     FOREIGN KEY (admin_id) REFERENCES admins(id)


### PR DESCRIPTION
## Summary
- add safe helper to extract file_unique_id from Telegram messages
- capture and persist file_unique_id during ingestion and duplicate replace flow
- use stored unique id on approval instead of reading from MessageId; include migrations for new column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9728f6548329a055bcf379fc1d88