### PR TITLE
ci/scripts: add import sanity checks + package __init__ files + CI workflow

### DIFF
--- a/.github/workflows/sanity_imports.yml
+++ b/.github/workflows/sanity_imports.yml
@@ -1,0 +1,25 @@
+name: Sanity Imports
+
+on:
+  push:
+    branches: [main_1]
+
+jobs:
+  import-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          else
+            pip install python-telegram-bot aiosqlite python-dotenv
+          fi
+      - name: Compile bytecode
+        run: python -m compileall -q bot keyboards
+      - name: Sanity import
+        run: python scripts/sanity_imports.py

--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -1,24 +1,36 @@
-"""
-Unified DB package exports (imports only; no I/O).
-Allows:
-  - import bot.db
-  - from bot.db import admins, topics, subjects, materials, years, lecturers
-"""
+"""Unified DB package with convenient re-exports."""
+
 from __future__ import annotations
 
-# Re-export submodules explicitly (no side effects here)
-from . import admins
-from . import topics
-from . import subjects
-from . import materials
-from . import years
-from . import lecturers
+from importlib import import_module
 
-__all__ = [
+_SUBMODULES = [
     "admins",
     "topics",
     "subjects",
     "materials",
     "years",
     "lecturers",
+    "groups",
+    "ingestions",
+    "term_resources",
 ]
+
+__all__ = ["init_db", "ensure_owner_full_perms", "is_owner", "has_perm", "MANAGE_ADMINS"]
+
+for _name in _SUBMODULES:
+    _mod = import_module(f"{__name__}.{_name}")
+    names = getattr(_mod, "__all__", dir(_mod))
+    for _attr in names:
+        if _attr.startswith("_"):
+            continue
+        globals()[_attr] = getattr(_mod, _attr)
+        if _attr not in __all__:
+            __all__.append(_attr)
+
+from .base import init_db
+from .admins import ensure_owner_full_perms, is_owner, has_perm, MANAGE_ADMINS
+from .years import get_or_create as get_or_create_year
+from .lecturers import get_or_create as get_or_create_lecturer
+
+__all__.extend(["get_or_create_year", "get_or_create_lecturer"])

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -1,0 +1,28 @@
+"""Convenience re-exports for handler callables."""
+
+from .start import start
+from .navigation import echo_handler
+from .topics import insert_sub_conv, insert_sub_private
+from .ingestion import ingestion_handler, duplicate_callback
+from .groups import insert_group_conv, insert_group_private
+from .admins import admins_conv
+from .approvals import approvals_handler, approval_callback
+from .moderation import moderation_handler
+from .misc import me_handler, version_handler
+
+__all__ = [
+    "start",
+    "echo_handler",
+    "insert_sub_conv",
+    "insert_sub_private",
+    "ingestion_handler",
+    "duplicate_callback",
+    "insert_group_conv",
+    "insert_group_private",
+    "admins_conv",
+    "approvals_handler",
+    "approval_callback",
+    "moderation_handler",
+    "me_handler",
+    "version_handler",
+]

--- a/bot/keyboards/__init__.py
+++ b/bot/keyboards/__init__.py
@@ -1,0 +1,5 @@
+"""Re-export common keyboard builders."""
+
+from .admins import build_permissions_keyboard
+
+__all__ = ["build_permissions_keyboard"]

--- a/scripts/sanity_imports.py
+++ b/scripts/sanity_imports.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Import every project module to ensure wiring is valid."""
+
+from __future__ import annotations
+
+import compileall
+import importlib
+import os
+import sys
+import traceback
+from pathlib import Path
+
+# Provide dummy environment variables so config imports don't fail.
+os.environ.setdefault("BOT_TOKEN", "dummy")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "0")
+os.environ.setdefault("OWNER_TG_ID", "0")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Compile all modules to bytecode to catch syntax errors.
+if not compileall.compile_dir(REPO_ROOT / "bot", quiet=1):
+    sys.exit(1)
+if not compileall.compile_dir(REPO_ROOT / "keyboards", quiet=1):
+    sys.exit(1)
+
+modules: list[str] = []
+for base in ("bot", "keyboards"):
+    for path in (REPO_ROOT / base).rglob("*.py"):
+        if path.name == "__init__.py":
+            continue
+        module = ".".join(path.relative_to(REPO_ROOT).with_suffix("").parts)
+        modules.append(module)
+
+for name in sorted(modules):
+    try:
+        importlib.import_module(name)
+        print(f"PASS {name}")
+    except Exception:
+        print(f"FAIL {name}")
+        traceback.print_exc()
+        sys.exit(1)
+
+print("All imports passed")


### PR DESCRIPTION
## Summary
- expose DB helpers and handler callables at package level
- sanity-import every module and compile bytecode
- run imports in CI on push to `main_1`

## Testing
- `python -m compileall -q bot keyboards`
- `python scripts/sanity_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab9f6a8304832993e88671c15a63ea