### PR TITLE
ci/scripts: stronger semantic checks tailored for Python 3.12.4

### DIFF
--- a/scripts/dev_check.py
+++ b/scripts/dev_check.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Run development sanity checks."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+def run(args: list[str]) -> None:
+    proc = subprocess.run([sys.executable, *args], cwd=ROOT)
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
+
+if __name__ == "__main__":
+    run(["scripts/sanity_imports.py"])
+    run(["scripts/audit_incompletes.py"])
+    run(["scripts/smoke_checks.py"])

--- a/scripts/smoke_checks.py
+++ b/scripts/smoke_checks.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Quick semantic checks ensuring runtime environment sanity."""
+from __future__ import annotations
+
+import compileall
+import os
+import sys
+from pathlib import Path
+
+# Show Python version early
+print(f"Python: {sys.version}")
+
+# Provide dummy environment variables so config imports don't fail
+os.environ.setdefault("BOT_TOKEN", "dummy")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "0")
+os.environ.setdefault("OWNER_TG_ID", "0")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# asyncio import and loop policy sanity
+# ---------------------------------------------------------------------------
+try:
+    import asyncio
+    policy = asyncio.get_event_loop_policy()
+    if policy.__class__.__name__ == "WindowsSelectorEventLoopPolicy":
+        print("سياسة الحلقة الافتراضية قديمة وغير مدعومة في بايثون ٣٫١٢")
+        sys.exit(1)
+except Exception as e:
+    print(f"فشل استيراد asyncio: {e}")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Compile all modules to bytecode (redundant but useful)
+# ---------------------------------------------------------------------------
+for mod in ("bot", "keyboards"):
+    if not compileall.compile_dir(REPO_ROOT / mod, quiet=1):
+        print(f"تعذر ترجمة ملفات {mod}")
+        sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# python-telegram-bot version check
+# ---------------------------------------------------------------------------
+try:
+    import telegram
+    parts = tuple(int(p) for p in telegram.__version__.split(".")[:2])
+    if parts < (20, 8):
+        print("الرجاء التحديث إلى python-telegram-bot 20.8 أو أحدث")
+        sys.exit(1)
+except Exception as e:
+    print(f"تعذر استيراد مكتبة telegram: {e}")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# uvloop import is optional and skipped on Windows
+# ---------------------------------------------------------------------------
+if sys.platform != "win32":
+    try:
+        import uvloop  # noqa: F401
+    except ImportError:
+        pass
+    except Exception as e:
+        print(f"مشكلة عند استيراد uvloop: {e}")
+        sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Import critical modules and verify important callables
+# ---------------------------------------------------------------------------
+try:
+    import bot.main  # noqa: F401
+    from bot.db import admins, topics
+    from bot import parser
+except Exception as e:
+    print(f"فشل استيراد الوحدات الأساسية: {e}")
+    sys.exit(1)
+
+for name in ("is_owner", "has_perm", "ensure_owner_full_perms"):
+    if not callable(getattr(admins, name, None)):
+        print(f"الدالة {name} غير موجودة في admins")
+        sys.exit(1)
+
+for name in ("bind", "get_binding"):
+    if not callable(getattr(topics, name, None)):
+        print(f"الدالة {name} غير موجودة في topics")
+        sys.exit(1)
+
+if not callable(getattr(parser, "extract_hijri_year", None)):
+    print("الدالة extract_hijri_year غير موجودة في parser")
+    sys.exit(1)
+
+print("جميع الفحوصات ناجحة")


### PR DESCRIPTION
## Summary
- add smoke checks ensuring asyncio policy, python-telegram-bot version, optional uvloop, and critical callable presence
- introduce `dev_check.py` to run sanity imports, incomplete audit, and smoke checks in one go

## Testing
- `python scripts/smoke_checks.py` *(fails: الدالة extract_hijri_year غير موجودة في parser)*
- `python scripts/dev_check.py` *(fails: /workspace/mechatronics_archive_bot_telegram/scripts/audit_incompletes.py: [Errno 2] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aba0ff9bfc8329b0306bae7829a870