### PR TITLE
Fix subject creation import for topic binding

### DIFF
--- a/bot/db/__init__.py
+++ b/bot/db/__init__.py
@@ -32,5 +32,6 @@ from .base import init_db
 from .admins import ensure_owner_full_perms, is_owner, has_perm, MANAGE_ADMINS
 from .years import get_or_create as get_or_create_year
 from .lecturers import get_or_create as get_or_create_lecturer
+from .subjects import get_or_create as get_or_create_subject
 
-__all__.extend(["get_or_create_year", "get_or_create_lecturer"])
+__all__.extend(["get_or_create_year", "get_or_create_lecturer", "get_or_create_subject"])

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -17,8 +17,8 @@ from bot.db import (
     get_group_id_by_chat,
     get_binding,
     bind,
-    get_or_create,
     set_theory_only,
+    get_or_create_subject,
 )
 from bot.utils.conv import conv_push, conv_cleanup
 from bot.utils.telegram import send_ephemeral
@@ -178,7 +178,7 @@ async def insert_sub_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE)
             context.chat_data.pop("insert_sub", None)
             return ConversationHandler.END
         _, level_id, term_id = group_info
-        subject = await get_or_create(term_id, info["subject_name"], level_id=level_id)
+        subject = await get_or_create_subject(term_id, info["subject_name"], level_id=level_id)
         await set_theory_only(subject.id, info.get("theory_only", False))
         await bind(chat.id, info["thread_id"], subject.id, info["section"])
         logger.info(


### PR DESCRIPTION
## Summary
- Import and use `get_or_create_subject` in topic handler to ensure proper signature
- Expose `get_or_create_subject` from `bot.db` to avoid future conflicts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba270d3dc832986c18cc0837ad422