### PR TITLE
fix(nav/section): تطبيع رمز القسم + الاستعلام بمحتوى approved + أوامر تشخيصية

### DIFF
--- a/bot/db/ingestions.py
+++ b/bot/db/ingestions.py
@@ -35,13 +35,14 @@ async def attach_material(
         await db.commit()
 
 
-async def list_pending_ingestions() -> list[tuple[int, int, int, str]]:
-    """Return pending ingestions with source identifiers and action."""
+async def list_pending_ingestions() -> list[tuple[int, int, str, int, int, str]]:
+    """Return pending ingestions with subject and section details."""
 
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
             """
-            SELECT i.id, m.source_chat_id, i.tg_message_id, i.action
+            SELECT i.id, m.subject_id, m.section, m.source_chat_id,
+                   i.tg_message_id, i.action
             FROM ingestions i
             JOIN materials m ON m.id = i.material_id
             WHERE i.status='pending'

--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -441,56 +441,115 @@ async def list_categories_for_lecture(
 # Simplified access helpers for navigation
 # -----------------------------------------------------------------------------
 
-async def get_years(subject_id: int, section: str) -> list[int]:
+async def get_years(
+    subject_id: int, section: str, only_approved: bool = True
+) -> list[int]:
     """Return available Hijri years for *subject* and *section*."""
-    rows = await get_years_for_subject_section(subject_id, section)
-    return [int(name) for _id, name in rows]
+    async with aiosqlite.connect(DB_PATH) as db:
+        q = (
+            """
+            SELECT DISTINCT y.name
+            FROM materials m
+            JOIN years y ON y.id = m.year_id
+            JOIN ingestions i ON i.material_id = m.id
+            WHERE m.subject_id=? AND m.section=? AND m.year_id IS NOT NULL
+            """
+        )
+        params: list = [subject_id, section]
+        if only_approved:
+            q += " AND i.status='approved'"
+        q += " ORDER BY y.name"
+        cur = await db.execute(q, params)
+        rows = await cur.fetchall()
+        return [int(r[0]) for r in rows]
 
 
-async def get_lectures_by_year(subject_id: int, section: str, year_id: int) -> list[dict]:
-    """Return lectures within a specific *year_id* with extracted numbers."""
-    titles = await list_lecture_titles_by_year(subject_id, section, year_id)
+async def get_lectures_by_year(
+    subject_id: int, section: str, year: int, only_approved: bool = True
+) -> list[dict]:
+    """Return lectures within a specific *year* with extracted numbers."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        q = (
+            """
+            SELECT m.title
+            FROM materials m
+            JOIN years y ON y.id = m.year_id
+            JOIN ingestions i ON i.material_id = m.id
+            WHERE m.subject_id=? AND m.section=? AND y.name=? AND m.category='lecture'
+            """
+        )
+        params: list = [subject_id, section, str(year)]
+        if only_approved:
+            q += " AND i.status='approved'"
+        q += " ORDER BY m.title"
+        cur = await db.execute(q, params)
+        titles = [r[0] for r in await cur.fetchall()]
+
     lectures: list[dict] = []
     for t in titles:
         m = re.search(r"(\d+)", t)
         no = int(m.group(1)) if m else len(lectures) + 1
         title = t.split(":", 1)[1].strip() if ":" in t else ""
-        lectures.append({"lecture_no": no, "title": title, "raw": t})
+        lectures.append({"lecture_no": no, "title": title})
     return lectures
 
 
 async def get_types_for_lecture(
     subject_id: int,
     section: str,
-    year_id: int,
-    lecture_title: str,
+    year: int,
+    lecture_no: int,
+    only_approved: bool = True,
 ) -> dict[str, tuple[int, str | None, int | None, int | None]]:
     """Return available types for a lecture mapped to material records."""
-    cats = await list_categories_for_lecture(subject_id, section, lecture_title, year_id=year_id)
-    result: dict[str, tuple[int, str | None, int | None, int | None]] = {}
-    for cat in cats:
-        mats = await get_materials_by_category(
-            subject_id, section, cat, year_id=year_id, title=lecture_title
+    async with aiosqlite.connect(DB_PATH) as db:
+        q = (
+            """
+            SELECT m.category, m.id, m.url, m.tg_storage_chat_id, m.tg_storage_msg_id
+            FROM materials m
+            JOIN years y ON y.id = m.year_id
+            JOIN ingestions i ON i.material_id = m.id
+            WHERE m.subject_id=? AND m.section=? AND y.name=? AND m.title LIKE ?
+            """
         )
-        if mats:
-            _id, title, url, chat_id, msg_id = mats[0]
-            result[cat] = (_id, url, chat_id, msg_id)
+        params: list = [subject_id, section, str(year), f"%{lecture_no}%"]
+        if only_approved:
+            q += " AND i.status='approved'"
+        cur = await db.execute(q, params)
+        rows = await cur.fetchall()
+
+    result: dict[str, tuple[int, str | None, int | None, int | None]] = {}
+    for cat, _id, url, chat_id, msg_id in rows:
+        result[cat] = (_id, url, chat_id, msg_id)
     return result
 
 
-async def get_year_specials(subject_id: int, section: str, year_id: int) -> dict:
+async def get_year_specials(
+    subject_id: int, section: str, year: int, only_approved: bool = True
+) -> dict:
     """Return flags for booklet and exam models in a year."""
-    booklet = bool(
-        await get_materials_by_category(subject_id, section, "booklet", year_id=year_id)
-    )
-    exam_mid = bool(
-        await get_materials_by_category(subject_id, section, "exam_mid", year_id=year_id)
-    )
-    exam_final = bool(
-        await get_materials_by_category(subject_id, section, "exam_final", year_id=year_id)
-    )
+    async with aiosqlite.connect(DB_PATH) as db:
+        q = (
+            """
+            SELECT
+                SUM(CASE WHEN m.category='booklet' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN m.category='exam_mid' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN m.category='exam_final' THEN 1 ELSE 0 END)
+            FROM materials m
+            JOIN years y ON y.id = m.year_id
+            JOIN ingestions i ON i.material_id = m.id
+            WHERE m.subject_id=? AND m.section=? AND y.name=?
+            """
+        )
+        params: list = [subject_id, section, str(year)]
+        if only_approved:
+            q += " AND i.status='approved'"
+        cur = await db.execute(q, params)
+        row = await cur.fetchone()
+
+    booklet, exam_mid, exam_final = row if row else (0, 0, 0)
     return {
-        "has_booklet": booklet,
-        "has_exam_mid": exam_mid,
-        "has_exam_final": exam_final,
+        "has_booklet": bool(booklet),
+        "has_exam_mid": bool(exam_mid),
+        "has_exam_final": bool(exam_final),
     }

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -9,6 +9,7 @@ from .admins import admins_conv
 from .approvals import approvals_handler, approval_callback
 from .moderation import moderation_handler
 from .misc import me_handler, version_handler
+from .diag import diag_subject_handler
 
 __all__ = [
     "start",
@@ -25,4 +26,5 @@ __all__ = [
     "moderation_handler",
     "me_handler",
     "version_handler",
+    "diag_subject_handler",
 ]

--- a/bot/handlers/approvals.py
+++ b/bot/handlers/approvals.py
@@ -16,6 +16,7 @@ from ..db.materials import update_material_storage
 from ..utils.telegram import (
     get_file_unique_id_from_message as _get_file_unique_id_from_message,  # noqa: F401
 )
+from ..utils.normalize import display_section
 
 
 logger = logging.getLogger("bot.approvals")
@@ -30,12 +31,15 @@ async def list_pending(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         await update.message.reply_text("لا توجد رسائل معلقة.")
         return
     await update.message.reply_text("الرسائل المعلقة:")
-    for ingestion_id, chat_id, msg_id, action_type in pending:
+    for ingestion_id, subject_id, section_code, chat_id, msg_id, action_type in pending:
         approve_label = "Approve استبدال" if action_type == "replace" else "Approve"
         buttons = [[
             InlineKeyboardButton(approve_label, callback_data=f"appr:{ingestion_id}"),
             InlineKeyboardButton("Reject", callback_data=f"rej:{ingestion_id}"),
         ]]
+        await update.message.reply_text(
+            f"#{ingestion_id} subject={subject_id} section={display_section(section_code)}"
+        )
         await context.bot.copy_message(
             chat_id=update.effective_chat.id,
             from_chat_id=chat_id,

--- a/bot/handlers/diag.py
+++ b/bot/handlers/diag.py
@@ -1,0 +1,53 @@
+import logging
+from telegram import Update
+from telegram.ext import CommandHandler, ContextTypes, filters
+
+from ..db import is_owner
+from ..db.materials import get_years, get_lectures_by_year, get_types_for_lecture
+from ..navigation import NavigationState
+from ..utils.normalize import normalize_section
+from ..db.base import DB_PATH
+import aiosqlite
+
+logger = logging.getLogger("bot.diag")
+
+async def diag_subject(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user = update.effective_user
+    if not user or not await is_owner(user.id):
+        return
+    nav = NavigationState(context.user_data)
+    subject_id = nav.data.get("subject_id")
+    section_code = normalize_section(nav.data.get("section"))
+    if not subject_id or not section_code:
+        await update.message.reply_text("حدد مادة وقسم عبر التصفح ثم أعد المحاولة.")
+        return
+    years = await get_years(subject_id, section_code, only_approved=False)
+    lines = [f"subject_id={subject_id}, section={section_code}, years={years}"]
+    async with aiosqlite.connect(DB_PATH) as db:
+        for year in years:
+            lectures = await get_lectures_by_year(subject_id, section_code, year, only_approved=False)
+            lines.append(f"{year}: {len(lectures)} lectures")
+            for lec in lectures:
+                types = await get_types_for_lecture(subject_id, section_code, year, lec["lecture_no"], only_approved=False)
+                lines.append(f"  lec{lec['lecture_no']}: {list(types.keys())}")
+            cur = await db.execute(
+                """
+                SELECT
+                    SUM(CASE WHEN i.status='approved' THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN i.status='pending' THEN 1 ELSE 0 END)
+                FROM materials m
+                JOIN ingestions i ON i.material_id = m.id
+                JOIN years y ON y.id = m.year_id
+                WHERE m.subject_id=? AND m.section=? AND y.name=?
+                """,
+                (subject_id, section_code, str(year)),
+            )
+            row = await cur.fetchone()
+            approved, pending = row if row else (0, 0)
+            lines.append(f"  counts: approved={approved or 0}, pending={pending or 0}")
+    await update.message.reply_text("\n".join(lines))
+
+
+diag_subject_handler = CommandHandler("diag_subject", diag_subject, filters.ChatType.PRIVATE)
+
+__all__ = ["diag_subject_handler"]

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -18,6 +18,7 @@ from ..db import (
 from ..db.materials import insert_material, find_exact
 from ..parser.hashtags import parse_hashtags
 from ..utils.telegram import send_ephemeral, get_file_unique_id_from_message
+from ..utils.normalize import display_section, normalize_section
 
 
 logger = logging.getLogger(__name__)
@@ -84,7 +85,7 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             )
             return
         subject_id = binding["subject_id"]
-        section = binding["section"]
+        section = normalize_section(binding["section"])
         subject_name = binding["subject_name"]
     else:
         subject_id = section = subject_name = None
@@ -177,7 +178,7 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     )
 
     summary = (
-        f"المادة: {subject_name}\nالقسم: {section}\nالسنة: {year or '---'}\nالنوع: {category}\nالعنوان: {title}"
+        f"المادة: {subject_name}\nالقسم: {display_section(section)}\nالسنة: {year or '---'}\nالنوع: {category}\nالعنوان: {title}"
     )
     buttons = [
         [
@@ -228,7 +229,7 @@ async def handle_duplicate_decision(
     )
     summary = (
         "طلب استبدال ملف مرفوع سابقًا\n"
-        f"المادة: {data['subject_name']}\nالقسم: {data['section']}\n"
+        f"المادة: {data['subject_name']}\nالقسم: {display_section(data['section'])}\n"
         f"السنة: {data['year'] or '---'}\nالنوع: {data['category']}\nالعنوان: {data['title']}"
     )
     buttons = [

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -65,6 +65,7 @@ from ..keyboards.builders import (
 )
 
 from ..utils.formatting import arabic_ordinal, to_display_name
+from ..utils.normalize import normalize_section
 from ..utils.telegram import build_archive_link
 from ..config import ARCHIVE_CHANNEL_ID
 
@@ -372,16 +373,22 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return await update.message.reply_text("ابدأ باختيار المادة ثم القسم.", reply_markup=main_menu)
 
         if text == FILTER_BY_YEAR:
-            years_rows = await get_years_for_subject_section(subject_id, section_code)
-            if not years_rows:
+            section_code = normalize_section(section_code)
+            years = await get_years(subject_id, section_code)
+            logger.info(
+                "list years subject=%s section=%s count=%s",
+                subject_id,
+                section_code,
+                len(years),
+            )
+            if not years:
                 return await update.message.reply_text(
                     "لا توجد سنوات لهذا القسم.",
                     reply_markup=generate_subject_sections_keyboard_dynamic([]),
                 )
-            years_map = {str(name): _id for _id, name in years_rows}
+            years_map = {str(y): y for y in years}
             nav.data["years_map"] = years_map
             nav.push_view("year_list")
-            years = [int(name) for name in years_map.keys()]
             return await update.message.reply_text(
                 "اختر السنة:",
                 reply_markup=build_years_menu(years),
@@ -414,6 +421,7 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     lecturer_id = nav.data.get("lecturer_id")
 
     if subject_id and section_code:
+        section_code = normalize_section(section_code)
         years_map = nav.data.get("years_map", {})
         if lecturer_id and text in years_map:
             year_id = years_map[text]
@@ -432,11 +440,16 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 reply_markup=generate_year_category_menu_keyboard(cats, lectures_exist),
             )
         if not lecturer_id and text in years_map:
-            year_id = years_map[text]
-            nav.set_year(text, year_id)
-            titles = await list_lecture_titles_by_year(subject_id, section_code, year_id)
-            lectures_exist = bool(titles)
-            cats = await list_categories_for_subject_section_year(subject_id, section_code, year_id)
+            year = years_map[text]
+            nav.set_year(text, year)
+            lectures = await get_lectures_by_year(subject_id, section_code, year)
+            lectures_exist = bool(lectures)
+            specials = await get_year_specials(subject_id, section_code, year)
+            cats: list[str] = []
+            if specials.get("has_booklet"):
+                cats.append("booklet")
+            if specials.get("has_exam_mid") or specials.get("has_exam_final"):
+                cats.append("exam")
             nav.push_view("year_category_menu")
             return await update.message.reply_text(
                 f"السنة: {text}\nاختر نوع المحتوى:",
@@ -505,28 +518,29 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
             # (أ) زر "📚 المحاضرات" من شاشة السنة
             if text == YEAR_MENU_LECTURES:
-                if lecturer_id and year_id:
-                    lectures = await get_lectures_by_year(subject_id, section_code, year_id)
-                else:
-                    lectures = await get_lectures_by_year(subject_id, section_code, year_id)
-
+                year = nav.data.get("year_id")
+                lectures = await get_lectures_by_year(subject_id, section_code, year)
+                logger.info(
+                    "list lectures subject=%s section=%s year=%s count=%s",
+                    subject_id,
+                    section_code,
+                    year,
+                    len(lectures),
+                )
                 if not lectures:
-                    cats = await list_categories_for_subject_section_year(
-                        subject_id, section_code, year_id, lecturer_id=lecturer_id
-                    )
                     return await update.message.reply_text(
-                        "لا توجد محاضرات لهذه السنة.",
-                        reply_markup=generate_year_category_menu_keyboard(cats, False),
+                        "لا توجد محاضرات معتمدة لهذه السنة حتى الآن.",
+                        reply_markup=build_lectures_menu([]),
                     )
 
                 nav.push_view("lecture_list")
                 markup = build_lectures_menu(lectures)
-                lectures_map = {}
+                lectures_map = { }
                 for item in lectures:
                     label = f"المحاضرة {arabic_ordinal(item['lecture_no'])}"
                     if item.get('title'):
                         label += f": {item['title']}"
-                    lectures_map[label] = item.get("raw", "")
+                    lectures_map[label] = item["lecture_no"]
                 nav.data["lectures_map"] = lectures_map
                 return await update.message.reply_text(
                     "اختر محاضرة:", reply_markup=markup
@@ -601,79 +615,27 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # 8.3) اختيار عنوان محاضرة → عرض تصنيفات المحاضرة
     if subject_id and section_code:
-        year_id = nav.data.get("year_id")
-        lecturer_id = nav.data.get("lecturer_id")
+        year = nav.data.get("year_id")
         lectures_map = nav.data.get("lectures_map", {})
 
         if text in lectures_map:
-            lecture_title = lectures_map[text] or text
-            nav.set_lecture(lecture_title)
+            lecture_no = lectures_map[text]
+            nav.set_lecture(text)
             nav.push_view("lecture_category_menu")
 
             types_map = await get_types_for_lecture(
-                subject_id, section_code, year_id, lecture_title
+                subject_id, section_code, year, lecture_no
             )
             if not types_map:
-                mats = await get_lecture_materials(
-                    subject_id,
-                    section_code,
-                    year_id=year_id,
-                    lecturer_id=lecturer_id,
-                    title=lecture_title,
-                )
-                if mats:
-                    for _id, title, url, chat_id, msg_id in mats:
-                        if msg_id and chat_id:
-                            link = None
-                            if chat_id == ARCHIVE_CHANNEL_ID:
-                                link = build_archive_link(chat_id, msg_id)
-                            markup = (
-                                InlineKeyboardMarkup(
-                                    [[InlineKeyboardButton("🔗 فتح في الأرشيف", url=link)]]
-                                )
-                                if link
-                                else None
-                            )
-                            await context.bot.copy_message(
-                                chat_id=update.effective_chat.id,
-                                from_chat_id=chat_id,
-                                message_id=msg_id,
-                                reply_markup=markup,
-                            )
-                            logger.info(
-                                "send subject=%s section=%s year=%s lecture=%s type=%s",
-                                subject_id,
-                                section_code,
-                                year_id,
-                                lecture_title,
-                                category,
-                            )
-                        elif url:
-                            await update.message.reply_text(f"📄 {title}\n{url}")
-                    nav.back_one()
-                    lectures = await get_lectures_by_year(subject_id, section_code, year_id)
-                    markup = build_lectures_menu(lectures)
-                    new_map = {}
-                    for item in lectures:
-                        label = f"المحاضرة {arabic_ordinal(item['lecture_no'])}"
-                        if item.get('title'):
-                            label += f": {item['title']}"
-                        new_map[label] = item.get("raw", "")
-                    nav.data["lectures_map"] = new_map
-                    return await update.message.reply_text("اختر محاضرة أخرى:", reply_markup=markup)
-
                 nav.back_one()
-                lectures = await get_lectures_by_year(subject_id, section_code, year_id)
-                markup = build_lectures_menu(lectures)
-                new_map = {}
-                for item in lectures:
-                    label = f"المحاضرة {arabic_ordinal(item['lecture_no'])}"
-                    if item.get('title'):
-                        label += f": {item['title']}"
-                    new_map[label] = item.get("raw", "")
-                nav.data["lectures_map"] = new_map
+                lectures = await get_lectures_by_year(subject_id, section_code, year)
+                nav.data["lectures_map"] = {
+                    (f"المحاضرة {arabic_ordinal(it['lecture_no'])}" + (f": {it['title']}" if it.get('title') else "")): it["lecture_no"]
+                    for it in lectures
+                }
                 return await update.message.reply_text(
-                    "لا توجد أنواع ملفات لهذه المحاضرة.", reply_markup=markup
+                    "لا توجد أنواع ملفات لهذه المحاضرة.",
+                    reply_markup=build_lectures_menu(lectures),
                 )
 
             nav.data["types_map"] = types_map

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -22,23 +22,12 @@ from bot.db import (
 )
 from bot.utils.conv import conv_push, conv_cleanup
 from bot.utils.telegram import send_ephemeral
+from bot.utils.normalize import normalize_section, display_section
 
 logger = logging.getLogger("bot.binding")
 
 START, AWAIT_INPUT, ASK_THEORY_ONLY, CONFIRM = range(4)
 
-SECTION_ALIASES = {
-    "نظري": "theory",
-    "مناقشة": "discussion",
-    "مناقشه": "discussion",
-    "عملي": "lab",
-}
-
-SECTION_LABELS = {
-    "theory": "نظري",
-    "discussion": "مناقشة",
-    "lab": "عملي",
-}
 
 FULL_RE = re.compile(r"^(?P<subject>[^-]+?)\s*-\s*(?P<section>نظري|عملي|مناقشة)\s*$")
 NAME_RE = re.compile(r"^(?P<subject>.+?)\s*$")
@@ -62,7 +51,10 @@ async def insert_sub_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     existing = await get_binding(chat.id, thread_id)
     if existing:
-        msg = f"هذا الـTopic مربوط حاليًا بـ: {existing['subject_name']} — {SECTION_LABELS.get(existing['section'], existing['section'])}."
+        msg = (
+            f"هذا الـTopic مربوط حاليًا بـ: {existing['subject_name']} —"
+            f" {display_section(existing['section'])}."
+        )
         buttons = [[
             InlineKeyboardButton("تعديل الربط", callback_data="sub_manual"),
             InlineKeyboardButton("إلغاء", callback_data="sub_cancel"),
@@ -106,12 +98,14 @@ async def insert_sub_received(update: Update, context: ContextTypes.DEFAULT_TYPE
     if m_full:
         subject = m_full.group("subject").strip()
         sect_label = m_full.group("section")
-        section = SECTION_ALIASES[sect_label]
-        info.update({
-            "subject_name": subject,
-            "section": section,
-            "theory_only": False,
-        })
+        section = normalize_section(sect_label) or "theory"
+        info.update(
+            {
+                "subject_name": subject,
+                "section": section,
+                "theory_only": False,
+            }
+        )
         theory_label = "لا"
         buttons = [[
             InlineKeyboardButton("تأكيد", callback_data="sub_confirm"),
@@ -159,7 +153,7 @@ async def insert_sub_theory_choice(update: Update, context: ContextTypes.DEFAULT
         InlineKeyboardButton("إلغاء", callback_data="sub_cancel"),
     ]]
     await query.edit_message_text(
-        f"سيتم ربط هذا الـTopic بـ:\nالمادة: {subject}\nالقسم: نظري\nنظري فقط: {theory_label}",
+        f"سيتم ربط هذا الـTopic بـ:\nالمادة: {subject}\nالقسم: {display_section('theory')}\nنظري فقط: {theory_label}",
         reply_markup=InlineKeyboardMarkup(buttons),
     )
     return CONFIRM

--- a/bot/main.py
+++ b/bot/main.py
@@ -30,6 +30,7 @@ from .handlers import (
     moderation_handler,
     me_handler,
     version_handler,
+    diag_subject_handler,
 )
 from .jobs import purge_temp_archives
 from datetime import time
@@ -91,6 +92,7 @@ def main():
             filters.ChatType.PRIVATE & filters.TEXT & ~filters.COMMAND, echo_handler
         )
     )
+    app.add_handler(diag_subject_handler)
 
     app.job_queue.run_daily(purge_temp_archives, time=time(hour=0, minute=0))
 

--- a/bot/utils/normalize.py
+++ b/bot/utils/normalize.py
@@ -1,0 +1,28 @@
+def normalize_section(s: str | None) -> str | None:
+    """Return canonical section code (theory/discussion/lab) or None.
+    Accepts Arabic labels and English codes, ignoring case and spaces.
+    """
+    if not s:
+        return None
+    key = s.strip().lower()
+    mapping = {
+        "نظري": "theory",
+        "عملي": "lab",
+        "مناقشة": "discussion",
+        "مناقشه": "discussion",
+        "theory": "theory",
+        "lab": "lab",
+        "discussion": "discussion",
+    }
+    return mapping.get(key)
+
+def display_section(code: str) -> str:
+    """Return Arabic label for a canonical *code*."""
+    labels = {
+        "theory": "نظري",
+        "discussion": "مناقشة",
+        "lab": "عملي",
+    }
+    return labels.get(code, code)
+
+__all__ = ["normalize_section", "display_section"]


### PR DESCRIPTION
## Summary
- normalize section codes for binding and lookups
- filter navigation queries to approved materials with helpful notices
- add /diag_subject command for owners to inspect subject/section/year stats

## Testing
- `pytest`
- `python -m py_compile bot/utils/normalize.py bot/handlers/topics.py bot/handlers/ingestion.py bot/handlers/approvals.py bot/db/ingestions.py bot/db/materials.py bot/handlers/navigation.py bot/handlers/diag.py bot/handlers/__init__.py bot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68aba68c4d7c83298c5ce15ad5b846b5