### PR TITLE
feat(nav): توليد كامل لقوائم السنة→المحاضرات→الأنواع وإرسال الرسالة المؤرشفة عند الاختيار

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -524,6 +524,44 @@ async def get_types_for_lecture(
     return result
 
 
+async def get_material(
+    subject_id: int,
+    section: str,
+    year: int,
+    lecture_no: int,
+    content_type: str,
+    lecturer_id: int | None = None,
+    only_approved: bool = True,
+) -> tuple[int, str | None, int | None, int | None] | None:
+    """Return a material row for a specific lecture content type."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        q = (
+            """
+            SELECT m.id, m.url, m.tg_storage_chat_id, m.tg_storage_msg_id
+            FROM materials m
+            JOIN years y ON y.id = m.year_id
+            JOIN ingestions i ON i.material_id = m.id
+            WHERE m.subject_id=? AND m.section=? AND y.name=? AND m.category=? AND m.title LIKE ?
+            """
+        )
+        params: list = [
+            subject_id,
+            section,
+            str(year),
+            content_type,
+            f"%{lecture_no}%",
+        ]
+        if lecturer_id is not None:
+            q += " AND m.lecturer_id=?"
+            params.append(lecturer_id)
+        if only_approved:
+            q += " AND i.status='approved'"
+        q += " ORDER BY m.id LIMIT 1"
+        cur = await db.execute(q, tuple(params))
+        row = await cur.fetchone()
+    return (row[0], row[1], row[2], row[3]) if row else None
+
+
 async def get_year_specials(
     subject_id: int, section: str, year: int, only_approved: bool = True
 ) -> dict:

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -24,6 +24,7 @@ from bot.db import (
     get_years,
     get_lectures_by_year,
     get_types_for_lecture,
+    get_material,
     get_year_specials,
 )
 
@@ -621,71 +622,83 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if text in lectures_map:
             lecture_no = lectures_map[text]
             nav.set_lecture(text)
+            nav.data["lecture_no"] = lecture_no
             nav.push_view("lecture_category_menu")
 
             types_map = await get_types_for_lecture(
                 subject_id, section_code, year, lecture_no
             )
             if not types_map:
-                nav.back_one()
-                lectures = await get_lectures_by_year(subject_id, section_code, year)
-                nav.data["lectures_map"] = {
-                    (f"المحاضرة {arabic_ordinal(it['lecture_no'])}" + (f": {it['title']}" if it.get('title') else "")): it["lecture_no"]
-                    for it in lectures
-                }
                 return await update.message.reply_text(
                     "لا توجد أنواع ملفات لهذه المحاضرة.",
-                    reply_markup=build_lectures_menu(lectures),
+                    reply_markup=build_types_menu({}),
                 )
 
             nav.data["types_map"] = types_map
+            type_label_map = {
+                CATEGORY_TO_LABEL.get(cat, to_display_name(cat)): cat
+                for cat in types_map
+            }
+            nav.data["type_label_map"] = type_label_map
             return await update.message.reply_text(
                 "اختر نوع الملف:",
-                reply_markup=build_types_menu(list(types_map.keys())),
+                reply_markup=build_types_menu(types_map),
             )
 
 
   
     # 8.4) اختيار تصنيف داخل "قائمة تصنيفات المحاضرة"
-    if text in LABEL_TO_CATEGORY:
+    type_label_map = nav.data.get("type_label_map", {})
+    if text in type_label_map:
         stack = nav.stack
         current = stack[-1][0] if stack else None
 
         if current == "lecture_category_menu":
-            category = LABEL_TO_CATEGORY[text]
-            types_map = nav.data.get("types_map", {})
-            material = types_map.get(category)
-            if material:
-                _id, url, chat_id, msg_id = material
-                if msg_id and chat_id:
-                    link = None
-                    if chat_id == ARCHIVE_CHANNEL_ID:
-                        link = build_archive_link(chat_id, msg_id)
-                    markup = (
-                        InlineKeyboardMarkup(
-                            [[InlineKeyboardButton("🔗 فتح في الأرشيف", url=link)]]
-                        )
-                        if link
-                        else None
+            category = type_label_map[text]
+            year = nav.data.get("year_id")
+            lecture_no = nav.data.get("lecture_no")
+            lecturer_id = nav.data.get("lecturer_id")
+            material = await get_material(
+                subject_id, section_code, year, lecture_no, category, lecturer_id
+            )
+            if material and material[2] and material[3]:
+                chat_id, msg_id = material[2], material[3]
+                link = None
+                if chat_id == ARCHIVE_CHANNEL_ID:
+                    link = build_archive_link(chat_id, msg_id)
+                markup = (
+                    InlineKeyboardMarkup(
+                        [[InlineKeyboardButton("🔗 فتح في الأرشيف", url=link)]]
                     )
-                    await context.bot.copy_message(
-                        chat_id=update.effective_chat.id,
-                        from_chat_id=chat_id,
-                        message_id=msg_id,
-                        reply_markup=markup,
-                    )
-                    logger.info(
-                        "send subject=%s section=%s year=%s lecture=%s type=%s",
-                        subject_id,
-                        section_code,
-                        nav.data.get("year_id"),
-                        nav.data.get("lecture_title"),
-                        category,
-                    )
-                elif url:
-                    await update.message.reply_text(f"📄 {text}\n{url}")
+                    if link
+                    else None
+                )
+                await context.bot.copy_message(
+                    chat_id=update.effective_chat.id,
+                    from_chat_id=chat_id,
+                    message_id=msg_id,
+                    reply_markup=markup,
+                )
+                logger.info(
+                    "send subject=%s section=%s year=%s lecture=%s type=%s",
+                    subject_id,
+                    section_code,
+                    year,
+                    nav.data.get("lecture_title"),
+                    category,
+                )
+            else:
+                await update.message.reply_text("العنصر غير متاح حاليًا.")
+                logger.warning(
+                    "missing material subject=%s section=%s year=%s lecture=%s type=%s",
+                    subject_id,
+                    section_code,
+                    year,
+                    nav.data.get("lecture_title"),
+                    category,
+                )
             return await update.message.reply_text(
-                "اختر نوعًا آخر:", reply_markup=build_types_menu(list(types_map.keys()))
+                "اختر نوعًا آخر:", reply_markup=build_types_menu(nav.data.get("types_map", {}))
             )
 
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -208,8 +208,10 @@ def generate_lecture_category_menu_keyboard(categories: list[str]) -> ReplyKeybo
 
 def build_years_menu(years: list[int]) -> ReplyKeyboardMarkup:
     """Build a simple menu for available years."""
-    labels = [str(y) for y in years]
+    labels = [str(y) for y in years if y]
     keyboard = _rows(labels, cols=2)
+    if not keyboard:
+        keyboard = []
     keyboard.append([BACK])
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
@@ -219,20 +221,27 @@ def build_lectures_menu(lectures: list[dict]) -> ReplyKeyboardMarkup:
     labels: list[str] = []
     for item in lectures:
         no = item.get("lecture_no")
+        if not no:
+            continue
         title = item.get("title", "")
-        label = f"المحاضرة {arabic_ordinal(no)}"
+        label = f"المحاضرة {arabic_ordinal(int(no))}"
         if title:
             label += f": {title}"
         labels.append(label)
     keyboard = _rows(labels, cols=1)
+    if not keyboard:
+        keyboard = []
     keyboard.append([BACK])
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def build_types_menu(types: list[str]) -> ReplyKeyboardMarkup:
+def build_types_menu(types: dict[str, object]) -> ReplyKeyboardMarkup:
     """Build menu for available content types."""
-    labels = [CATEGORY_TO_LABEL.get(t, t) for t in types]
+    labels = [CATEGORY_TO_LABEL.get(t, to_display_name(t)) for t in types.keys()]
+    labels = [lbl for lbl in labels if lbl]
     keyboard = _rows(labels, cols=2)
+    if not keyboard:
+        keyboard = []
     keyboard.append([BACK])
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 


### PR DESCRIPTION
## Summary
- دعم مولدات القوائم للسنة والمحاضرات والأنواع مع أزرار رجوع آمنة
- إضافة دالة get_material لجلب الرسالة المؤرشفة المعتمدة
- تحديث مسار التنقل لنسخ الرسالة المؤرشفة وإظهار تنبيهات عند عدم توفر محتوى

## Testing
- `python -m py_compile bot/keyboards/builders.py bot/handlers/navigation.py bot/db/materials.py bot/utils/formatting.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abaacd6698832980a6dde1f850e50e