### PR TITLE
feat: show tagless materials with guidance

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -360,10 +360,10 @@ async def get_materials_by_category(
     """
     params = [subject_id, section, category]
     if year_id is not None:
-        q += " AND year_id=?"
+        q += " AND (year_id=? OR year_id IS NULL)"
         params.append(year_id)
     if lecturer_id is not None:
-        q += " AND lecturer_id=?"
+        q += " AND (lecturer_id=? OR lecturer_id IS NULL)"
         params.append(lecturer_id)
     if title is not None:
         q += " AND title=?"

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -566,13 +566,36 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     year_id=year_id, lecturer_id=lecturer_id
                 )
                 if not mats:
-                    titles_exist = False
-                    if lecturer_id and year_id:
-                        titles_exist = bool(await list_lecture_titles_by_lecturer_year(subject_id, section_code, lecturer_id, year_id))
+                    fallback_mats = await get_materials_by_category(
+                        subject_id, section_code, category
+                    )
+                    if fallback_mats:
+                        await update.message.reply_text(
+                            "لم يُعثَر على ملفات لهذا التصنيف ضمن السنة أو المحاضر المحدَّدين. "
+                            "تم عرض نتائج بدون تقييد، فالرجاء التحقق من وسوم السنة والمحاضر إذا اختلفت.",
+                        )
+                        mats = fallback_mats
                     else:
-                        titles_exist = bool(await list_lecture_titles_by_year(subject_id, section_code, year_id))
-                    cats = await list_categories_for_subject_section_year(subject_id, section_code, year_id, lecturer_id=lecturer_id)
-                    return await update.message.reply_text("لا توجد ملفات لهذا التصنيف.", reply_markup=generate_year_category_menu_keyboard(cats, titles_exist))
+                        titles_exist = False
+                        if lecturer_id and year_id:
+                            titles_exist = bool(
+                                await list_lecture_titles_by_lecturer_year(
+                                    subject_id, section_code, lecturer_id, year_id
+                                )
+                            )
+                        else:
+                            titles_exist = bool(
+                                await list_lecture_titles_by_year(
+                                    subject_id, section_code, year_id
+                                )
+                            )
+                        cats = await list_categories_for_subject_section_year(
+                            subject_id, section_code, year_id, lecturer_id=lecturer_id
+                        )
+                        return await update.message.reply_text(
+                            "لا توجد ملفات لهذا التصنيف. قد تكون السنة غير مطابقة أو الوسوم ناقصة.",
+                            reply_markup=generate_year_category_menu_keyboard(cats, titles_exist),
+                        )
 
                 for _id, title, url, chat_id, msg_id in mats:
                     if msg_id and chat_id:


### PR DESCRIPTION
## Summary
- include materials without year/lecturer tags when filtering by category
- fall back to unfiltered materials and prompt users to check tags when no results found
- clarify missing-content error messages

## Testing
- `python -m py_compile bot/db/materials.py bot/handlers/navigation.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abb10de6408329bf11e76e96d6d8c1