### PR TITLE
Validate #الملزمة hashtag usage

### DIFF
--- a/bot/parser/hashtags.py
+++ b/bot/parser/hashtags.py
@@ -179,6 +179,19 @@ def parse_hashtags(text: str) -> Tuple[ParsedHashtags, str | None]:
         return info, msg
 
     ct = info.content_type
+    has_booklet_tag = any(
+        CONTENT_TYPE_ALIASES.get(t.split()[0].lstrip("#")) == "booklet"
+        for t in tags
+    )
+    has_board_tag = any(
+        CONTENT_TYPE_ALIASES.get(t.split()[0].lstrip("#")) == "board_images"
+        for t in tags
+    )
+    if has_booklet_tag and (info.lecture_no or has_board_tag):
+        return _err(
+            "هذا الوسم خاص بالملازم. لنشر صور المحاضرة استخدم: #صور_السبورة\n"
+            "#المحاضرة_1: العنوان\n#1446"
+        )
     if ct in {"daily_brief", "board_images"}:
         expected = ["content", "lecture", "year"]
         if sequence[:3] != expected:

--- a/tests/parser/test_hashtags.py
+++ b/tests/parser/test_hashtags.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from bot.parser.hashtags import parse_hashtags
+
+
+def test_booklet_with_lecture_suggests_board_images():
+    text = "#الملزمة\n#المحاضرة_1: عنوان\n#1446"
+    _, error = parse_hashtags(text)
+    assert error is not None
+    assert "#صور_السبورة" in error


### PR DESCRIPTION
## Summary
- ensure #الملزمة isn't combined with lecture tags or board images and provide a hint to use #صور_السبورة
- add regression test for the guidance message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb25f14b08329aac968580ceca4fb