### PR TITLE
feat(nav): dynamic lecture menus for year and lecturer

### DIFF
--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -1,4 +1,6 @@
 import logging
+import re
+
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
@@ -412,9 +414,30 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if text == LIST_LECTURES:
             titles = await list_lecture_titles(subject_id, section_code)
             if not titles:
-                return await update.message.reply_text("لا توجد محاضرات متاحة.", reply_markup=generate_subject_sections_keyboard_dynamic([]))
+                return await update.message.reply_text(
+                    "لا توجد محاضرات متاحة.",
+                    reply_markup=generate_subject_sections_keyboard_dynamic([]),
+                )
+
+            # استخرج أرقام المحاضرات والعناوين المنسقة لعرض زرود مرتبة
+            lectures: list[dict] = []
+            for t in titles:
+                m = re.search(r"(\d+)", t)
+                no = int(m.group(1)) if m else len(lectures) + 1
+                title = t.split(":", 1)[1].strip() if ":" in t else ""
+                lectures.append({"lecture_no": no, "title": title})
+
             nav.push_view("lecture_list")
-            return await update.message.reply_text("اختر محاضرة:", reply_markup=generate_lecture_titles_keyboard(titles))
+            markup = build_lectures_menu(lectures)
+            lectures_map: dict[str, int] = {}
+            for item in lectures:
+                label = f"المحاضرة {arabic_ordinal(int(item['lecture_no']))}"
+                clean = to_display_name(item.get("title", ""))
+                if clean:
+                    label += f": {clean}"
+                lectures_map[label] = item["lecture_no"]
+            nav.data["lectures_map"] = lectures_map
+            return await update.message.reply_text("اختر محاضرة:", reply_markup=markup)
 
     # 8.2) اختيار سنة/محاضر
     subject_id = nav.data.get("subject_id")
@@ -499,10 +522,27 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     "لا توجد محاضرات لهذا المحاضر.",
                     reply_markup=generate_lecturer_filter_keyboard(bool(years), False),
                 )
+
+            lectures: list[dict] = []
+            for t in titles:
+                m = re.search(r"(\d+)", t)
+                no = int(m.group(1)) if m else len(lectures) + 1
+                title = t.split(":", 1)[1].strip() if ":" in t else ""
+                lectures.append({"lecture_no": no, "title": title})
+
             nav.push_view("lecture_list")
+            markup = build_lectures_menu(lectures)
+            lectures_map: dict[str, int] = {}
+            for item in lectures:
+                label = f"المحاضرة {arabic_ordinal(int(item['lecture_no']))}"
+                clean = to_display_name(item.get("title", ""))
+                if clean:
+                    label += f": {clean}"
+                lectures_map[label] = item["lecture_no"]
+            nav.data["lectures_map"] = lectures_map
             return await update.message.reply_text(
                 f"محاضرات الدكتور {lecturer_label}:",
-                reply_markup=generate_lecture_titles_keyboard(titles),
+                reply_markup=markup,
             )
 
 
@@ -536,11 +576,12 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
                 nav.push_view("lecture_list")
                 markup = build_lectures_menu(lectures)
-                lectures_map = { }
+                lectures_map: dict[str, int] = {}
                 for item in lectures:
                     label = f"المحاضرة {arabic_ordinal(item['lecture_no'])}"
-                    if item.get('title'):
-                        label += f": {item['title']}"
+                    clean = to_display_name(item.get('title', ''))
+                    if clean:
+                        label += f": {clean}"
                     lectures_map[label] = item["lecture_no"]
                 nav.data["lectures_map"] = lectures_map
                 return await update.message.reply_text(

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -155,7 +155,9 @@ def generate_lecturers_keyboard(lecturers: list[tuple[int, str]]) -> ReplyKeyboa
 
 def generate_lecture_titles_keyboard(titles: list[str]) -> ReplyKeyboardMarkup:
     """Display lecture titles."""
-    keyboard = _rows(titles, cols=2)
+    # Clean up titles to avoid underscores or hidden characters in buttons
+    names = [to_display_name(t) for t in titles]
+    keyboard = _rows(names, cols=2)
     keyboard.append([BACK, BACK_TO_SUBJECTS])
     keyboard.append([BACK_TO_LEVELS])
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
@@ -223,7 +225,8 @@ def build_lectures_menu(lectures: list[dict]) -> ReplyKeyboardMarkup:
         no = item.get("lecture_no")
         if not no:
             continue
-        title = item.get("title", "")
+        # Sanitize the title to remove underscores or direction markers
+        title = to_display_name(item.get("title", ""))
         label = f"المحاضرة {arabic_ordinal(int(no))}"
         if title:
             label += f": {title}"


### PR DESCRIPTION
## Summary
- sanitize lecture titles and numbers in keyboards for cleaner buttons
- support listing lectures by year or lecturer with formatted mapping
- ensure materials are sent with archive link buttons

## Testing
- `pytest -q`
- `python -m py_compile bot/handlers/navigation.py bot/keyboards/builders.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb674b9388329bed8309fe37e7d92