### PR TITLE
utils: إضافة أدوات arabic_ordinal/to_display_name + تطبيع القسم

### DIFF
--- a/bot/utils/formatting.py
+++ b/bot/utils/formatting.py
@@ -1,5 +1,6 @@
 import re
 
+
 ARABIC_ORDINALS = {
     1: "الأولى",
     2: "الثانية",
@@ -11,6 +12,16 @@ ARABIC_ORDINALS = {
     8: "الثامنة",
     9: "التاسعة",
     10: "العاشرة",
+    11: "الحادية عشرة",
+    12: "الثانية عشرة",
+    13: "الثالثة عشرة",
+    14: "الرابعة عشرة",
+    15: "الخامسة عشرة",
+    16: "السادسة عشرة",
+    17: "السابعة عشرة",
+    18: "الثامنة عشرة",
+    19: "التاسعة عشرة",
+    20: "العشرون",
 }
 
 
@@ -19,11 +30,14 @@ def arabic_ordinal(n: int) -> str:
     return ARABIC_ORDINALS.get(n, str(n))
 
 
+_BIDI_RE = re.compile(r"[\u200e\u200f\u202a-\u202e\u2066-\u2069]")
+
+
 def to_display_name(value: str) -> str:
     """Normalize *value* by removing direction markers and underscores."""
     if not value:
         return ""
-    cleaned = re.sub(r"[\u200e\u200f]", "", value)
+    cleaned = _BIDI_RE.sub("", value)
     return cleaned.replace("_", " ").strip()
 
 

--- a/bot/utils/normalize.py
+++ b/bot/utils/normalize.py
@@ -1,10 +1,15 @@
+import re
+
+
 def normalize_section(s: str | None) -> str | None:
-    """Return canonical section code (theory/discussion/lab) or None.
-    Accepts Arabic labels and English codes, ignoring case and spaces.
+    """Return canonical section code (theory/lab/discussion) or ``None``.
+
+    Accepts Arabic labels or English codes, ignoring case, spaces and
+    underscores.
     """
     if not s:
         return None
-    key = s.strip().lower()
+    key = re.sub(r"[_\s]+", "", s).lower()
     mapping = {
         "نظري": "theory",
         "عملي": "lab",


### PR DESCRIPTION
## Summary
- expand Arabic ordinal helper to cover 1..20 and strip bidi characters in display names
- add section normalization helpers and Arabic display mapping

## Testing
- `pytest`
- `python - <<'PY'
from bot.utils.formatting import arabic_ordinal, to_display_name
from bot.utils.normalize import normalize_section, display_section
print(arabic_ordinal(1))
print(arabic_ordinal(15))
print(to_display_name('الدكتور_صالح\u200f'))
print(normalize_section('نظري'))
print(normalize_section('discussion'))
print(display_section('lab'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68abb81c08b08329a9877a76babbd752