### PR TITLE
ui(nav): قائمة المادة/القسم مع الأزرار الأساسية

### DIFF
--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -55,7 +55,7 @@ from ..keyboards.builders import (
     generate_term_menu_keyboard_dynamic,
     generate_subject_sections_keyboard_dynamic,
     generate_lecturer_filter_keyboard,
-    generate_section_filters_keyboard_dynamic,
+    build_subject_section_menu,
     generate_years_keyboard,
     generate_lecturers_keyboard,
     generate_lecture_titles_keyboard,
@@ -120,12 +120,13 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if top_type == "section":
         subject_id = nav.data.get("subject_id")
         section_code = nav.data.get("section")
-        years = await get_years_for_subject_section(subject_id, section_code)
         lecturers = await get_lecturers_for_subject_section(subject_id, section_code)
-        lectures_exist = await has_lecture_category(subject_id, section_code)
+        has_syllabus = bool(
+            await get_materials_by_category(subject_id, section_code, "syllabus")
+        )
         return await update.message.reply_text(
-            "اختر طريقة التصفية:",
-            reply_markup=generate_section_filters_keyboard_dynamic(bool(years), bool(lecturers), lectures_exist),
+            "اختر:",
+            reply_markup=build_subject_section_menu(has_syllabus, bool(lecturers)),
         )
 
     if top_type == "year":
@@ -358,14 +359,14 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         nav.set_section(text, section_code)
 
         subject_id = nav.data.get("subject_id")
-
-        years = await get_years_for_subject_section(subject_id, section_code)
         lecturers = await get_lecturers_for_subject_section(subject_id, section_code)
-        lectures_exist = await has_lecture_category(subject_id, section_code)
+        has_syllabus = bool(
+            await get_materials_by_category(subject_id, section_code, "syllabus")
+        )
 
         return await update.message.reply_text(
-            "اختر طريقة التصفية:",
-            reply_markup=generate_section_filters_keyboard_dynamic(bool(years), bool(lecturers), lectures_exist),
+            "اختر:",
+            reply_markup=build_subject_section_menu(has_syllabus, bool(lecturers)),
         )
 
     # 8.1) تصفية حسب السنة/المحاضر/عرض كل المحاضرات

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -1,4 +1,4 @@
-from telegram import ReplyKeyboardMarkup
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeyboardMarkup
 
 from .constants import (
     TERM_MENU_SHOW_SUBJECTS,
@@ -133,6 +133,25 @@ def generate_section_filters_keyboard_dynamic(
     keyboard.append([BACK, BACK_TO_SUBJECTS])
     keyboard.append([BACK_TO_LEVELS])
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def build_subject_section_menu(
+    has_syllabus: bool, has_lecturers: bool
+) -> InlineKeyboardMarkup:
+    """Build inline menu for a subject's section."""
+    row: list[InlineKeyboardButton] = [
+        InlineKeyboardButton(FILTER_BY_YEAR, callback_data="year")
+    ]
+    if has_lecturers:
+        row.append(InlineKeyboardButton(FILTER_BY_LECTURER, callback_data="lecturer"))
+
+    keyboard: list[list[InlineKeyboardButton]] = [row]
+    if has_syllabus:
+        keyboard.append(
+            [InlineKeyboardButton("📄 التوصيف", callback_data="syllabus")]
+        )
+    keyboard.append([InlineKeyboardButton(BACK, callback_data="back")])
+    return InlineKeyboardMarkup(keyboard)
 
 
 def generate_years_keyboard(years: list[tuple[int, str]]) -> ReplyKeyboardMarkup:
@@ -277,6 +296,7 @@ __all__ = [
     "generate_lecturer_filter_keyboard",
     "generate_year_category_menu_keyboard",
     "generate_lecture_category_menu_keyboard",
+    "build_subject_section_menu",
     "build_years_menu",
     "build_lectures_menu",
     "build_types_menu",


### PR DESCRIPTION
## Summary
- add inline subject/section menu builder with optional lecturer and syllabus buttons
- integrate subject section menu into navigation flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb8e805a48329b159d93191816a30