### PR TITLE
db(nav): دوال إرجاع السنوات المعتمدة وعرضها

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -444,24 +444,50 @@ async def list_categories_for_lecture(
 async def get_years(
     subject_id: int, section: str, only_approved: bool = True
 ) -> list[int]:
-    """Return available Hijri years for *subject* and *section*."""
+    """Return available Hijri years for *subject* and *section*.
+
+    The function looks up distinct years associated with a subject's *section*.
+    It supports both the modern ``year_id`` reference to the ``years`` table and
+    a legacy ``year`` column on ``materials`` if present. Only materials with an
+    ``approved`` ingestion status are considered by default.
+    """
+
     async with aiosqlite.connect(DB_PATH) as db:
-        q = (
-            """
-            SELECT DISTINCT y.name
-            FROM materials m
-            JOIN years y ON y.id = m.year_id
-            JOIN ingestions i ON i.material_id = m.id
-            WHERE m.subject_id=? AND m.section=? AND m.year_id IS NOT NULL
-            """
-        )
+        # Detect whether a legacy ``year`` column exists to maintain backward
+        # compatibility with older databases that didn't use ``year_id``.
+        cur = await db.execute("PRAGMA table_info(materials)")
+        cols = [row[1] for row in await cur.fetchall()]
+        has_year_col = "year" in cols
+
+        if has_year_col:
+            q = (
+                """
+                SELECT DISTINCT COALESCE(y.name, m.year) AS yname
+                FROM materials m
+                LEFT JOIN years y ON y.id = m.year_id
+                JOIN ingestions i ON i.material_id = m.id
+                WHERE m.subject_id=? AND m.section=?
+                  AND COALESCE(y.name, m.year) IS NOT NULL
+                """
+            )
+        else:
+            q = (
+                """
+                SELECT DISTINCT y.name AS yname
+                FROM materials m
+                JOIN years y ON y.id = m.year_id
+                JOIN ingestions i ON i.material_id = m.id
+                WHERE m.subject_id=? AND m.section=? AND m.year_id IS NOT NULL
+                """
+            )
+
         params: list = [subject_id, section]
         if only_approved:
             q += " AND i.status='approved'"
-        q += " ORDER BY y.name"
+        q += " ORDER BY yname"
         cur = await db.execute(q, params)
         rows = await cur.fetchall()
-        return [int(r[0]) for r in rows]
+        return [int(r[0]) for r in rows if r[0]]
 
 
 async def get_lectures_by_year(

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -10,7 +10,6 @@ from bot.db import (
     get_subjects_by_level_and_term,
     term_feature_flags,
     get_available_sections_for_subject,
-    get_years_for_subject_section,
     get_lecturers_for_subject_section,
     has_lecture_category,
     get_years_for_subject_section_lecturer,
@@ -56,7 +55,6 @@ from ..keyboards.builders import (
     generate_subject_sections_keyboard_dynamic,
     generate_lecturer_filter_keyboard,
     build_subject_section_menu,
-    generate_years_keyboard,
     generate_lecturers_keyboard,
     generate_lecture_titles_keyboard,
     generate_year_category_menu_keyboard,
@@ -154,13 +152,19 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         subject_id = nav.data.get("subject_id")
         section_code = nav.data.get("section")
         lecturer_id = nav.data.get("lecturer_id")
+        section_code = normalize_section(section_code)
         if lecturer_id:
-            years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)
+            years_pairs = await get_years_for_subject_section_lecturer(
+                subject_id, section_code, lecturer_id
+            )
+            years = [int(name) for _id, name in years_pairs]
             msg = "اختر السنة (للمحاضر المحدد):"
         else:
-            years = await get_years_for_subject_section(subject_id, section_code)
+            years = await get_years(subject_id, section_code)
             msg = "اختر السنة:"
-        return await update.message.reply_text(msg, reply_markup=generate_years_keyboard(years))
+        return await update.message.reply_text(
+            msg, reply_markup=build_years_menu(years)
+        )
 
     if top_type == "lecturer_list":
         subject_id = nav.data.get("subject_id")
@@ -501,22 +505,36 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         lecturer_label = next((lbl for t, lbl in nav.stack if t == "lecturer"), "")
 
         if not (subject_id and section_code and lecturer_id):
-            return await update.message.reply_text("ابدأ باختيار المادة → القسم → المحاضر.", reply_markup=main_menu)
+            return await update.message.reply_text(
+                "ابدأ باختيار المادة → القسم → المحاضر.", reply_markup=main_menu
+            )
 
         if text == CHOOSE_YEAR_FOR_LECTURER:
-            years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)
-            if not years:
+            years_pairs = await get_years_for_subject_section_lecturer(
+                subject_id, section_code, lecturer_id
+            )
+            if not years_pairs:
                 years_exist = False
-                lectures_exist = await list_lecture_titles_by_lecturer(subject_id, section_code, lecturer_id)
+                lectures_exist = await list_lecture_titles_by_lecturer(
+                    subject_id, section_code, lecturer_id
+                )
                 return await update.message.reply_text(
                     "لا توجد سنوات مرتبطة بمحاضرات هذا المحاضر.",
-                    reply_markup=generate_lecturer_filter_keyboard(years_exist, bool(lectures_exist)),
+                    reply_markup=generate_lecturer_filter_keyboard(
+                        years_exist, bool(lectures_exist)
+                    ),
                 )
+            years = [int(name) for _id, name in years_pairs]
             nav.push_view("year_list")
-            return await update.message.reply_text(f"المحاضر: {lecturer_label}\nاختر السنة:", reply_markup=generate_years_keyboard(years))
+            return await update.message.reply_text(
+                f"المحاضر: {lecturer_label}\nاختر السنة:",
+                reply_markup=build_years_menu(years),
+            )
 
         if text == LIST_LECTURES_FOR_LECTURER:
-            titles = await list_lecture_titles_by_lecturer(subject_id, section_code, lecturer_id)
+            titles = await list_lecture_titles_by_lecturer(
+                subject_id, section_code, lecturer_id
+            )
             if not titles:
                 years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)
                 return await update.message.reply_text(


### PR DESCRIPTION
## Summary
- دعم استرجاع سنوات الهجرية المعتمدة للمادة والقسم مع التعامل مع حقل year القديم إن وُجد
- عرض قائمة السنوات المعتمدة عند الضغط على "📂 حسب السنة" باستخدام لوحة مفاتيح مبسطة

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abba32d9b8832994be28281763630c