### PR TITLE
feat(nav-year): جذر السنة مع «المحاضرات/الملزمة/النماذج»

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -588,12 +588,10 @@ async def get_material(
     return (row[0], row[1], row[2], row[3]) if row else None
 
 
-async def get_year_specials(
-    subject_id: int, section: str, year: int, only_approved: bool = True
-) -> dict:
+async def get_year_specials(subject_id: int, section: str, year: int) -> dict:
     """Return flags for booklet and exam models in a year."""
     async with aiosqlite.connect(DB_PATH) as db:
-        q = (
+        cur = await db.execute(
             """
             SELECT
                 SUM(CASE WHEN m.category='booklet' THEN 1 ELSE 0 END),
@@ -603,12 +601,10 @@ async def get_year_specials(
             JOIN years y ON y.id = m.year_id
             JOIN ingestions i ON i.material_id = m.id
             WHERE m.subject_id=? AND m.section=? AND y.name=?
-            """
+              AND i.status='approved'
+            """,
+            (subject_id, section, str(year)),
         )
-        params: list = [subject_id, section, str(year)]
-        if only_approved:
-            q += " AND i.status='approved'"
-        cur = await db.execute(q, params)
         row = await cur.fetchone()
 
     booklet, exam_mid, exam_final = row if row else (0, 0, 0)

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -63,6 +63,7 @@ from ..keyboards.builders import (
     build_lectures_menu,
     build_types_menu,
     build_exam_menu,
+    build_year_root_menu,
 )
 
 from ..utils.formatting import arabic_ordinal, to_display_name
@@ -202,14 +203,27 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not year_id:
             return await render_state(update, context)
         if lecturer_id:
-            lectures_exist = bool(await list_lecture_titles_by_lecturer_year(subject_id, section_code, lecturer_id, year_id))
-            cats = await list_categories_for_subject_section_year(subject_id, section_code, year_id, lecturer_id=lecturer_id)
-        else:
-            lectures_exist = bool(await list_lecture_titles_by_year(subject_id, section_code, year_id))
-            cats = await list_categories_for_subject_section_year(subject_id, section_code, year_id)
+            lectures_exist = bool(
+                await list_lecture_titles_by_lecturer_year(
+                    subject_id, section_code, lecturer_id, year_id
+                )
+            )
+            cats = await list_categories_for_subject_section_year(
+                subject_id, section_code, year_id, lecturer_id=lecturer_id
+            )
+            return await update.message.reply_text(
+                "اختر نوع المحتوى:",
+                reply_markup=generate_year_category_menu_keyboard(cats, lectures_exist),
+            )
+
+        specials = await get_year_specials(subject_id, section_code, year_id)
+        nav.data["year_specials"] = specials
+        has_exams = specials.get("has_exam_mid") or specials.get("has_exam_final")
         return await update.message.reply_text(
             "اختر نوع المحتوى:",
-            reply_markup=generate_year_category_menu_keyboard(cats, lectures_exist),
+            reply_markup=build_year_root_menu(
+                specials.get("has_booklet"), has_exams
+            ),
         )
 
     if top_type == "lecture_category_menu":
@@ -471,18 +485,15 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not lecturer_id and text in years_map:
             year = years_map[text]
             nav.set_year(text, year)
-            lectures = await get_lectures_by_year(subject_id, section_code, year)
-            lectures_exist = bool(lectures)
             specials = await get_year_specials(subject_id, section_code, year)
-            cats: list[str] = []
-            if specials.get("has_booklet"):
-                cats.append("booklet")
-            if specials.get("has_exam_mid") or specials.get("has_exam_final"):
-                cats.append("exam")
+            nav.data["year_specials"] = specials
+            has_exams = specials.get("has_exam_mid") or specials.get("has_exam_final")
             nav.push_view("year_category_menu")
             return await update.message.reply_text(
                 f"السنة: {text}\nاختر نوع المحتوى:",
-                reply_markup=generate_year_category_menu_keyboard(cats, lectures_exist),
+                reply_markup=build_year_root_menu(
+                    specials.get("has_booklet"), has_exams
+                ),
             )
 
         # اختيار محاضر بالاسم
@@ -565,7 +576,61 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             )
 
 
-    # 8.2.x) داخل قائمة تصنيفات السنة (نفذ فقط إن كانت الشاشة الحالية هي year_category_menu)
+    # 8.2.x) داخل قائمة تصنيفات السنة أو قوائمها الفرعية
+    if text in {"الملزمة", "النماذج"}:
+        stack = nav.stack
+        current = stack[-1][0] if stack else None
+        lecturer_id = nav.data.get("lecturer_id")
+        if current == "year_category_menu" and not lecturer_id:
+            subject_id = nav.data.get("subject_id")
+            section_code = nav.data.get("section")
+            year_id = nav.data.get("year_id")
+            specials = nav.data.get("year_specials") or await get_year_specials(subject_id, section_code, year_id)
+
+            if text == "الملزمة":
+                mats = await get_materials_by_category(
+                    subject_id, section_code, "booklet", year_id=year_id
+                )
+                if not mats:
+                    await update.message.reply_text("لا توجد ملزمة لهذه السنة.")
+                else:
+                    for _id, title, url, chat_id, msg_id in mats:
+                        if msg_id and chat_id:
+                            link = None
+                            if chat_id == ARCHIVE_CHANNEL_ID:
+                                link = build_archive_link(chat_id, msg_id)
+                            markup = (
+                                InlineKeyboardMarkup(
+                                    [[InlineKeyboardButton("🔗 فتح في الأرشيف", url=link)]]
+                                )
+                                if link
+                                else None
+                            )
+                            await context.bot.copy_message(
+                                chat_id=update.effective_chat.id,
+                                from_chat_id=chat_id,
+                                message_id=msg_id,
+                                reply_markup=markup,
+                            )
+                        elif url:
+                            await update.message.reply_text(f"📄 {title}\n{url}")
+                has_exams = specials.get("has_exam_mid") or specials.get("has_exam_final")
+                return await update.message.reply_text(
+                    "اختر نوع المحتوى:",
+                    reply_markup=build_year_root_menu(
+                        specials.get("has_booklet"), has_exams
+                    ),
+                )
+
+            if text == "النماذج":
+                nav.push_view("exam_menu")
+                return await update.message.reply_text(
+                    "اختر النموذج:",
+                    reply_markup=build_exam_menu(
+                        specials.get("has_exam_mid"), specials.get("has_exam_final")
+                    ),
+                )
+
     if text == YEAR_MENU_LECTURES or text in LABEL_TO_CATEGORY:
         stack = nav.stack
         current = stack[-1][0] if stack else None
@@ -693,6 +758,49 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     titles_exist = bool(await list_lecture_titles_by_year(subject_id, section_code, year_id))
                 cats = await list_categories_for_subject_section_year(subject_id, section_code, year_id, lecturer_id=lecturer_id)
                 return await update.message.reply_text("اختر نوع محتوى آخر:", reply_markup=generate_year_category_menu_keyboard(cats, titles_exist))
+
+    if text in {"النصفي", "النهائي"}:
+        stack = nav.stack
+        current = stack[-1][0] if stack else None
+        if current == "exam_menu":
+            subject_id = nav.data.get("subject_id")
+            section_code = nav.data.get("section")
+            year_id = nav.data.get("year_id")
+            category = "exam_mid" if text == "النصفي" else "exam_final"
+            mats = await get_materials_by_category(
+                subject_id, section_code, category, year_id=year_id
+            )
+            if not mats:
+                await update.message.reply_text("لا توجد ملفات لهذا النموذج.")
+            else:
+                for _id, title, url, chat_id, msg_id in mats:
+                    if msg_id and chat_id:
+                        link = None
+                        if chat_id == ARCHIVE_CHANNEL_ID:
+                            link = build_archive_link(chat_id, msg_id)
+                        markup = (
+                            InlineKeyboardMarkup(
+                                [[InlineKeyboardButton("🔗 فتح في الأرشيف", url=link)]]
+                            )
+                            if link
+                            else None
+                        )
+                        await context.bot.copy_message(
+                            chat_id=update.effective_chat.id,
+                            from_chat_id=chat_id,
+                            message_id=msg_id,
+                            reply_markup=markup,
+                        )
+                    elif url:
+                        await update.message.reply_text(f"📄 {title}\n{url}")
+
+            specials = nav.data.get("year_specials") or await get_year_specials(subject_id, section_code, year_id)
+            return await update.message.reply_text(
+                "اختر النموذج:",
+                reply_markup=build_exam_menu(
+                    specials.get("has_exam_mid"), specials.get("has_exam_final")
+                ),
+            )
 
 
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -227,6 +227,18 @@ def generate_lecture_category_menu_keyboard(categories: list[str]) -> ReplyKeybo
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
+def build_year_root_menu(has_booklet: bool, has_exams: bool) -> ReplyKeyboardMarkup:
+    """Build root menu for a selected year."""
+    row: list[str] = [YEAR_MENU_LECTURES]
+    if has_booklet:
+        row.append("الملزمة")
+    if has_exams:
+        row.append("النماذج")
+
+    keyboard = [row, [BACK]]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
 def build_years_menu(years: list[int]) -> ReplyKeyboardMarkup:
     """Build a simple menu for available years."""
     labels = [str(y) for y in years if y]
@@ -297,6 +309,7 @@ __all__ = [
     "generate_year_category_menu_keyboard",
     "generate_lecture_category_menu_keyboard",
     "build_subject_section_menu",
+    "build_year_root_menu",
     "build_years_menu",
     "build_lectures_menu",
     "build_types_menu",


### PR DESCRIPTION
## Summary
- expose year specials without extra flags
- build root menu for year with lectures, booklet, and exam models
- wire navigation to show booklet/exam options when available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abbb67c2288329a38aeec7785df85b