### PR TITLE
feat(nav-year): قائمة المحاضرات بعناوين عربية منسّقة

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -490,25 +490,28 @@ async def get_years(
         return [int(r[0]) for r in rows if r[0]]
 
 
-async def get_lectures_by_year(
-    subject_id: int, section: str, year: int, only_approved: bool = True
-) -> list[dict]:
-    """Return lectures within a specific *year* with extracted numbers."""
+async def get_lectures_by_year(subject_id: int, section: str, year: int) -> list[dict]:
+    """Return available lectures for a given *year*.
+
+    Each lecture is returned as a ``{"lecture_no": int, "title": str}`` mapping.
+    The lecture number is extracted from the material title (first group of digits).
+    If no number is found, a sequential value is used instead.  Titles after a
+    colon are trimmed and returned without direction markers.
+    """
+
     async with aiosqlite.connect(DB_PATH) as db:
-        q = (
+        cur = await db.execute(
             """
             SELECT m.title
             FROM materials m
             JOIN years y ON y.id = m.year_id
-            JOIN ingestions i ON i.material_id = m.id
-            WHERE m.subject_id=? AND m.section=? AND y.name=? AND m.category='lecture'
-            """
+            WHERE m.subject_id=? AND m.section=? AND y.name=?
+              AND m.category='lecture'
+              AND (m.url IS NOT NULL OR m.tg_storage_msg_id IS NOT NULL)
+            ORDER BY m.title
+            """,
+            (subject_id, section, str(year)),
         )
-        params: list = [subject_id, section, str(year)]
-        if only_approved:
-            q += " AND i.status='approved'"
-        q += " ORDER BY m.title"
-        cur = await db.execute(q, params)
         titles = [r[0] for r in await cur.fetchall()]
 
     lectures: list[dict] = []
@@ -517,6 +520,7 @@ async def get_lectures_by_year(
         no = int(m.group(1)) if m else len(lectures) + 1
         title = t.split(":", 1)[1].strip() if ":" in t else ""
         lectures.append({"lecture_no": no, "title": title})
+
     return lectures
 
 

--- a/bot/handlers/diag.py
+++ b/bot/handlers/diag.py
@@ -25,10 +25,16 @@ async def diag_subject(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     lines = [f"subject_id={subject_id}, section={section_code}, years={years}"]
     async with aiosqlite.connect(DB_PATH) as db:
         for year in years:
-            lectures = await get_lectures_by_year(subject_id, section_code, year, only_approved=False)
+            lectures = await get_lectures_by_year(subject_id, section_code, year)
             lines.append(f"{year}: {len(lectures)} lectures")
             for lec in lectures:
-                types = await get_types_for_lecture(subject_id, section_code, year, lec["lecture_no"], only_approved=False)
+                types = await get_types_for_lecture(
+                    subject_id,
+                    section_code,
+                    year,
+                    lec["lecture_no"],
+                    only_approved=False,
+                )
                 lines.append(f"  lec{lec['lecture_no']}: {list(types.keys())}")
             cur = await db.execute(
                 """

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -438,7 +438,7 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     reply_markup=generate_subject_sections_keyboard_dynamic([]),
                 )
 
-            # استخرج أرقام المحاضرات والعناوين المنسقة لعرض زرود مرتبة
+            # استخرج أرقام المحاضرات وعناوينها المنسَّقة لعرضها بترتيب واضح
             lectures: list[dict] = []
             for t in titles:
                 m = re.search(r"(\d+)", t)
@@ -450,10 +450,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             markup = build_lectures_menu(lectures)
             lectures_map: dict[str, int] = {}
             for item in lectures:
-                label = f"المحاضرة {arabic_ordinal(int(item['lecture_no']))}"
-                clean = to_display_name(item.get("title", ""))
-                if clean:
-                    label += f": {clean}"
+                label = f"المحاضرة {arabic_ordinal(item['lecture_no'])}"
+                title = to_display_name(item.get("title", ""))
+                if title:
+                    label += f": {title}"
                 lectures_map[label] = item["lecture_no"]
             nav.data["lectures_map"] = lectures_map
             return await update.message.reply_text("اختر محاضرة:", reply_markup=markup)
@@ -663,9 +663,9 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 lectures_map: dict[str, int] = {}
                 for item in lectures:
                     label = f"المحاضرة {arabic_ordinal(item['lecture_no'])}"
-                    clean = to_display_name(item.get('title', ''))
-                    if clean:
-                        label += f": {clean}"
+                    title = to_display_name(item.get("title", ""))
+                    if title:
+                        label += f": {title}"
                     lectures_map[label] = item["lecture_no"]
                 nav.data["lectures_map"] = lectures_map
                 return await update.message.reply_text(

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -250,7 +250,14 @@ def build_years_menu(years: list[int]) -> ReplyKeyboardMarkup:
 
 
 def build_lectures_menu(lectures: list[dict]) -> ReplyKeyboardMarkup:
-    """Build lecture list with Arabic ordinals."""
+    """Build a keyboard listing lectures with Arabic ordinals.
+
+    ``lectures`` should contain dictionaries of ``{"lecture_no": int,
+    "title": str}``.  The resulting labels follow the pattern
+    ``"المحاضرة {ordinal}: {title}"`` where the title part is included only
+    when available.
+    """
+
     labels: list[str] = []
     for item in lectures:
         no = item.get("lecture_no")


### PR DESCRIPTION
## Summary
- list lectures for a subject/year and return lecture numbers with titles
- render lecture menus using Arabic ordinals and sanitized titles
- show lecture list when selecting "📚 المحاضرات" in the year view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abbcd546448329a9ec6e7ac2a512b2