### PR TITLE
feat(nav-lecture): قائمة أنواع المحتوى المتاحة دون فراغات

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -529,9 +529,15 @@ async def get_types_for_lecture(
     section: str,
     year: int,
     lecture_no: int,
-    only_approved: bool = True,
-) -> dict[str, tuple[int, str | None, int | None, int | None]]:
-    """Return available types for a lecture mapped to material records."""
+) -> dict[str, dict]:
+    """Return available types for a lecture mapped to material rows.
+
+    The returned dictionary maps each ``category`` to a row-like mapping with
+    ``id``, ``url``, ``tg_storage_chat_id`` and ``tg_storage_msg_id`` keys.
+    Empty or NULL records are skipped, ensuring callers receive only types that
+    have actual stored content (URL or Telegram message).
+    """
+
     async with aiosqlite.connect(DB_PATH) as db:
         q = (
             """
@@ -543,14 +549,20 @@ async def get_types_for_lecture(
             """
         )
         params: list = [subject_id, section, str(year), f"%{lecture_no}%"]
-        if only_approved:
-            q += " AND i.status='approved'"
+        q += " AND i.status='approved'"
         cur = await db.execute(q, params)
         rows = await cur.fetchall()
 
-    result: dict[str, tuple[int, str | None, int | None, int | None]] = {}
+    result: dict[str, dict] = {}
     for cat, _id, url, chat_id, msg_id in rows:
-        result[cat] = (_id, url, chat_id, msg_id)
+        if not url and not msg_id:
+            continue
+        result[cat] = {
+            "id": _id,
+            "url": url,
+            "tg_storage_chat_id": chat_id,
+            "tg_storage_msg_id": msg_id,
+        }
     return result
 
 

--- a/bot/handlers/diag.py
+++ b/bot/handlers/diag.py
@@ -33,7 +33,6 @@ async def diag_subject(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                     section_code,
                     year,
                     lec["lecture_no"],
-                    only_approved=False,
                 )
                 lines.append(f"  lec{lec['lecture_no']}: {list(types.keys())}")
             cur = await db.execute(

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -21,7 +21,6 @@ from bot.db import (
     get_materials_by_category,
     get_lecture_materials,
     list_categories_for_subject_section_year,
-    list_categories_for_lecture,
     get_years,
     get_lectures_by_year,
     get_types_for_lecture,
@@ -58,7 +57,6 @@ from ..keyboards.builders import (
     generate_lecturers_keyboard,
     generate_lecture_titles_keyboard,
     generate_year_category_menu_keyboard,
-    generate_lecture_category_menu_keyboard,
     build_years_menu,
     build_lectures_menu,
     build_types_menu,
@@ -227,14 +225,16 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
 
     if top_type == "lecture_category_menu":
-        subject_id = nav.data.get("subject_id")
-        section_code = nav.data.get("section")
-        year_id = nav.data.get("year_id")
-        lecturer_id = nav.data.get("lecturer_id")
         lecture_title = nav.data.get("lecture_title", "")
-        cats = await list_categories_for_lecture(subject_id, section_code, lecture_title, year_id=year_id, lecturer_id=lecturer_id)
-        msg = f"المحاضرة: {lecture_title}\nاختر نوع الملف:" if cats else "لا توجد أنواع ملفات لهذه المحاضرة."
-        return await update.message.reply_text(msg, reply_markup=generate_lecture_category_menu_keyboard(cats))
+        types_map = nav.data.get("types_map", {})
+        msg = (
+            f"المحاضرة: {lecture_title}\nاختر نوع الملف:"
+            if types_map
+            else "لا توجد أنواع ملفات لهذه المحاضرة."
+        )
+        return await update.message.reply_text(
+            msg, reply_markup=build_types_menu(types_map)
+        )
 
     return await update.message.reply_text("اختر من القائمة:", reply_markup=main_menu)
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -276,9 +276,18 @@ def build_lectures_menu(lectures: list[dict]) -> ReplyKeyboardMarkup:
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def build_types_menu(types: dict[str, object]) -> ReplyKeyboardMarkup:
-    """Build menu for available content types."""
-    labels = [CATEGORY_TO_LABEL.get(t, to_display_name(t)) for t in types.keys()]
+def build_types_menu(types: dict[str, dict]) -> ReplyKeyboardMarkup:
+    """Build menu for available content types.
+
+    ``types`` should map content category names to material rows.  Categories with
+    falsy rows are ignored.  The menu always includes a back button at the end.
+    """
+
+    labels = [
+        CATEGORY_TO_LABEL.get(cat, to_display_name(cat))
+        for cat, row in types.items()
+        if row
+    ]
     labels = [lbl for lbl in labels if lbl]
     keyboard = _rows(labels, cols=2)
     if not keyboard:


### PR DESCRIPTION
## Summary
- list available content types per lecture by returning full material rows
- build types menu without empty options
- show types menu on lecture selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abbe7d2e688329a9ec13b5883986b3