### PR TITLE
feat(nav-exams): قائمة النصفي/النهائي وإرسال الأرشيف

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -642,3 +642,27 @@ async def get_year_specials(subject_id: int, section: str, year: int) -> dict:
         "has_exam_mid": bool(exam_mid),
         "has_exam_final": bool(exam_final),
     }
+
+
+async def get_exam_mid(subject_id: int, section: str, year_id: int):
+    """Return approved midterm exam materials for a year."""
+    return await get_materials_by_category(
+        subject_id, section, "exam_mid", year_id=year_id
+    )
+
+
+async def get_exam_final(subject_id: int, section: str, year_id: int):
+    """Return approved final exam materials for a year."""
+    return await get_materials_by_category(
+        subject_id, section, "exam_final", year_id=year_id
+    )
+
+
+async def has_exam_mid(subject_id: int, section: str, year_id: int) -> bool:
+    """Check if midterm exam model exists for a year."""
+    return bool(await get_exam_mid(subject_id, section, year_id))
+
+
+async def has_exam_final(subject_id: int, section: str, year_id: int) -> bool:
+    """Check if final exam model exists for a year."""
+    return bool(await get_exam_final(subject_id, section, year_id))

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -26,6 +26,10 @@ from bot.db import (
     get_types_for_lecture,
     get_material,
     get_year_specials,
+    has_exam_mid,
+    has_exam_final,
+    get_exam_mid,
+    get_exam_final,
 )
 
 from ..keyboards.constants import (
@@ -60,7 +64,7 @@ from ..keyboards.builders import (
     build_years_menu,
     build_lectures_menu,
     build_types_menu,
-    build_exam_menu,
+    build_exams_menu,
     build_year_root_menu,
 )
 
@@ -624,11 +628,11 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
             if text == "النماذج":
                 nav.push_view("exam_menu")
+                mid_exists = await has_exam_mid(subject_id, section_code, year_id)
+                final_exists = await has_exam_final(subject_id, section_code, year_id)
                 return await update.message.reply_text(
                     "اختر النموذج:",
-                    reply_markup=build_exam_menu(
-                        specials.get("has_exam_mid"), specials.get("has_exam_final")
-                    ),
+                    reply_markup=build_exams_menu(mid_exists, final_exists),
                 )
 
     if text == YEAR_MENU_LECTURES or text in LABEL_TO_CATEGORY:
@@ -766,9 +770,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             subject_id = nav.data.get("subject_id")
             section_code = nav.data.get("section")
             year_id = nav.data.get("year_id")
-            category = "exam_mid" if text == "النصفي" else "exam_final"
-            mats = await get_materials_by_category(
-                subject_id, section_code, category, year_id=year_id
+            mats = (
+                await get_exam_mid(subject_id, section_code, year_id)
+                if text == "النصفي"
+                else await get_exam_final(subject_id, section_code, year_id)
             )
             if not mats:
                 await update.message.reply_text("لا توجد ملفات لهذا النموذج.")
@@ -794,12 +799,11 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     elif url:
                         await update.message.reply_text(f"📄 {title}\n{url}")
 
-            specials = nav.data.get("year_specials") or await get_year_specials(subject_id, section_code, year_id)
+            mid_exists = await has_exam_mid(subject_id, section_code, year_id)
+            final_exists = await has_exam_final(subject_id, section_code, year_id)
             return await update.message.reply_text(
                 "اختر النموذج:",
-                reply_markup=build_exam_menu(
-                    specials.get("has_exam_mid"), specials.get("has_exam_final")
-                ),
+                reply_markup=build_exams_menu(mid_exists, final_exists),
             )
 
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -296,7 +296,7 @@ def build_types_menu(types: dict[str, dict]) -> ReplyKeyboardMarkup:
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def build_exam_menu(mid_exists: bool, final_exists: bool) -> ReplyKeyboardMarkup:
+def build_exams_menu(mid_exists: bool, final_exists: bool) -> ReplyKeyboardMarkup:
     """Build submenu for exam models."""
     row: list[str] = []
     if mid_exists:
@@ -329,5 +329,5 @@ __all__ = [
     "build_years_menu",
     "build_lectures_menu",
     "build_types_menu",
-    "build_exam_menu",
+    "build_exams_menu",
 ]


### PR DESCRIPTION
## Summary
- add exams submenu builder for mid/final models
- add db helpers and navigation flow to send exam models via copyMessage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abc0f8b6008329987a73c5eaa5b17a