### PR TITLE
ux(nav): حماية من القوائم الفارغة ورسائل توضيحية مع لوج

### DIFF
--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -110,13 +110,32 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         subject_label = stack[-1][1] if stack else ""
         subject_id = nav.data.get("subject_id")
         sections = await get_available_sections_for_subject(subject_id) if subject_id else []
-        msg = f"المادة: {subject_label}\nاختر القسم:" if sections else "لا توجد أقسام متاحة لهذه المادة حتى الآن."
-        return await update.message.reply_text(msg, reply_markup=generate_subject_sections_keyboard_dynamic(sections))
+        logger.info(
+            "list sections subject=%s count=%s",
+            subject_id,
+            len(sections),
+        )
+        msg = (
+            f"المادة: {subject_label}\nاختر القسم:"
+            if sections
+            else "لا توجد أقسام متاحة لهذه المادة حتى الآن."
+        )
+        return await update.message.reply_text(
+            msg, reply_markup=generate_subject_sections_keyboard_dynamic(sections)
+        )
 
     if top_type == "subject_list":
         subjects = await get_subjects_by_level_and_term(level_id, term_id)
+        logger.info(
+            "list subjects level=%s term=%s count=%s",
+            level_id,
+            term_id,
+            len(subjects),
+        )
         msg = "اختر المادة:" if subjects else "لا توجد مواد لهذا الترم."
-        return await update.message.reply_text(msg, reply_markup=generate_subjects_keyboard(subjects))
+        return await update.message.reply_text(
+            msg, reply_markup=generate_subjects_keyboard(subjects)
+        )
 
     if top_type == "section":
         subject_id = nav.data.get("subject_id")
@@ -136,8 +155,14 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         year_label = stack[-1][1]
         year_id = nav.data.get("year_id")
         titles = await list_lecture_titles_by_year(subject_id, section_code, year_id)
-        msg = f"السنة: {year_label}\nاختر محاضرة:" if titles else "لا توجد محاضرات لهذه السنة."
-        return await update.message.reply_text(msg, reply_markup=generate_lecture_titles_keyboard(titles))
+        msg = (
+            f"السنة: {year_label}\nاختر محاضرة:"
+            if titles
+            else "لا توجد عناصر معتمدة هنا حاليًا."
+        )
+        return await update.message.reply_text(
+            msg, reply_markup=generate_lecture_titles_keyboard(titles)
+        )
 
     if top_type == "lecturer":
         subject_id = nav.data.get("subject_id")
@@ -165,6 +190,13 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         else:
             years = await get_years(subject_id, section_code)
             msg = "اختر السنة:"
+        logger.info(
+            "list years subject=%s section=%s lecturer=%s count=%s",
+            subject_id,
+            section_code,
+            lecturer_id,
+            len(years),
+        )
         return await update.message.reply_text(
             msg, reply_markup=build_years_menu(years)
         )
@@ -194,8 +226,12 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
             titles = await list_lecture_titles_by_year(subject_id, section_code, year_id)
             heading = "اختر محاضرة (حسب السنة):"
 
-        msg = heading if titles else "لا توجد محاضرات مطابقة."
-        return await update.message.reply_text(msg, reply_markup=generate_lecture_titles_keyboard(titles))
+        msg = (
+            heading if titles else "لا توجد عناصر معتمدة هنا حاليًا."
+        )
+        return await update.message.reply_text(
+            msg, reply_markup=generate_lecture_titles_keyboard(titles)
+        )
 
     if top_type == "year_category_menu":
         subject_id = nav.data.get("subject_id")
@@ -234,7 +270,7 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         msg = (
             f"المحاضرة: {lecture_title}\nاختر نوع الملف:"
             if types_map
-            else "لا توجد أنواع ملفات لهذه المحاضرة."
+            else "لا توجد عناصر معتمدة هنا حاليًا."
         )
         return await update.message.reply_text(
             msg, reply_markup=build_types_menu(types_map)
@@ -436,9 +472,15 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         if text == LIST_LECTURES:
             titles = await list_lecture_titles(subject_id, section_code)
+            logger.info(
+                "list lectures subject=%s section=%s count=%s",
+                subject_id,
+                section_code,
+                len(titles),
+            )
             if not titles:
                 return await update.message.reply_text(
-                    "لا توجد محاضرات متاحة.",
+                    "لا توجد عناصر معتمدة هنا حاليًا.",
                     reply_markup=generate_subject_sections_keyboard_dynamic([]),
                 )
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -39,7 +39,10 @@ def generate_levels_keyboard(levels: list) -> ReplyKeyboardMarkup:
     """Display available levels."""
     names = [name for _id, name in levels]
     keyboard = _rows(names, cols=2)
-    keyboard.append(["🔙 العودة للقائمة الرئيسية"])
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(
         keyboard=keyboard,
         resize_keyboard=True,
@@ -63,8 +66,11 @@ def generate_subjects_keyboard(subjects: list) -> ReplyKeyboardMarkup:
     """Display subjects for the current term."""
     names = [name for (name,) in subjects]
     keyboard = _rows(names, cols=2)
-    keyboard.append([BACK])
-    keyboard.append([BACK_TO_LEVELS])
+    if keyboard:
+        keyboard.append([BACK])
+        keyboard.append([BACK_TO_LEVELS])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(
         keyboard=keyboard,
         resize_keyboard=True,
@@ -110,7 +116,10 @@ def generate_subject_sections_keyboard_dynamic(sections: list[str]) -> ReplyKeyb
     """Display available sections for a subject."""
     labels = [SECTION_LABELS[s] for s in sections if s in SECTION_LABELS]
     keyboard = _rows(labels, cols=2)
-    keyboard.append([BACK])
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -158,8 +167,11 @@ def generate_years_keyboard(years: list[tuple[int, str]]) -> ReplyKeyboardMarkup
     """Display available years for a subject/section."""
     names = [name for _id, name in years]
     keyboard = _rows(names, cols=2)
-    keyboard.append([BACK, BACK_TO_SUBJECTS])
-    keyboard.append([BACK_TO_LEVELS])
+    if keyboard:
+        keyboard.append([BACK, BACK_TO_SUBJECTS])
+        keyboard.append([BACK_TO_LEVELS])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -167,8 +179,11 @@ def generate_lecturers_keyboard(lecturers: list[tuple[int, str]]) -> ReplyKeyboa
     """Display lecturers for the subject/section."""
     names = [to_display_name(name) for _id, name in lecturers]
     keyboard = _rows(names, cols=2)
-    keyboard.append([BACK, BACK_TO_SUBJECTS])
-    keyboard.append([BACK_TO_LEVELS])
+    if keyboard:
+        keyboard.append([BACK, BACK_TO_SUBJECTS])
+        keyboard.append([BACK_TO_LEVELS])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -177,8 +192,11 @@ def generate_lecture_titles_keyboard(titles: list[str]) -> ReplyKeyboardMarkup:
     # Clean up titles to avoid underscores or hidden characters in buttons
     names = [to_display_name(t) for t in titles]
     keyboard = _rows(names, cols=2)
-    keyboard.append([BACK, BACK_TO_SUBJECTS])
-    keyboard.append([BACK_TO_LEVELS])
+    if keyboard:
+        keyboard.append([BACK, BACK_TO_SUBJECTS])
+        keyboard.append([BACK_TO_LEVELS])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -195,7 +213,10 @@ def generate_lecturer_filter_keyboard(
     keyboard: list[list[str]] = []
     if row:
         keyboard.append(row)
-    keyboard.append([BACK])
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -213,8 +234,11 @@ def generate_year_category_menu_keyboard(
         keyboard.append(first_row)
     keyboard += _rows(labels, cols=2)
 
-    keyboard.append([BACK, BACK_TO_SUBJECTS])
-    keyboard.append([BACK_TO_LEVELS])
+    if keyboard:
+        keyboard.append([BACK, BACK_TO_SUBJECTS])
+        keyboard.append([BACK_TO_LEVELS])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -222,8 +246,11 @@ def generate_lecture_category_menu_keyboard(categories: list[str]) -> ReplyKeybo
     """Display categories for a specific lecture."""
     labels = [CATEGORY_TO_LABEL.get(c, c) for c in categories]
     keyboard = _rows(labels, cols=2)
-    keyboard.append([BACK, BACK_TO_SUBJECTS])
-    keyboard.append([BACK_TO_LEVELS])
+    if keyboard:
+        keyboard.append([BACK, BACK_TO_SUBJECTS])
+        keyboard.append([BACK_TO_LEVELS])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -243,9 +270,10 @@ def build_years_menu(years: list[int]) -> ReplyKeyboardMarkup:
     """Build a simple menu for available years."""
     labels = [str(y) for y in years if y]
     keyboard = _rows(labels, cols=2)
-    if not keyboard:
-        keyboard = []
-    keyboard.append([BACK])
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -270,9 +298,10 @@ def build_lectures_menu(lectures: list[dict]) -> ReplyKeyboardMarkup:
             label += f": {title}"
         labels.append(label)
     keyboard = _rows(labels, cols=1)
-    if not keyboard:
-        keyboard = []
-    keyboard.append([BACK])
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -290,9 +319,10 @@ def build_types_menu(types: dict[str, dict]) -> ReplyKeyboardMarkup:
     ]
     labels = [lbl for lbl in labels if lbl]
     keyboard = _rows(labels, cols=2)
-    if not keyboard:
-        keyboard = []
-    keyboard.append([BACK])
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
@@ -306,7 +336,10 @@ def build_exams_menu(mid_exists: bool, final_exists: bool) -> ReplyKeyboardMarku
     keyboard: list[list[str]] = []
     if row:
         keyboard.append(row)
-    keyboard.append([BACK])
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 


### PR DESCRIPTION
## Summary
- avoid empty navigation states with a friendly "no approved content" message
- log counts for subjects, sections and years to aid monitoring
- keyboard builders always include a back button to prevent blank keyboards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc273b6a4832999b096e5acb2016a