### PR TITLE
feat(nav-lecturers): جلب وعرض قائمة المحاضرين حسب المادة/القسم

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -441,6 +441,32 @@ async def list_categories_for_lecture(
 # Simplified access helpers for navigation
 # -----------------------------------------------------------------------------
 
+async def get_lecturers(subject_id: int, section: str) -> list[dict]:
+    """Return lecturers with approved materials for *subject* and *section*.
+
+    Each lecturer is returned as ``{"id": int, "tag": str, "display": str}``.
+    Only lecturers linked to materials that have at least one approved
+    ingestion and stored content (URL or Telegram message) are included.
+    """
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            """
+            SELECT DISTINCT l.id, l.name
+            FROM materials m
+            JOIN lecturers l ON l.id = m.lecturer_id
+            JOIN ingestions i ON i.material_id = m.id
+            WHERE m.subject_id = ? AND m.section = ? AND m.lecturer_id IS NOT NULL
+              AND (m.url IS NOT NULL OR m.tg_storage_msg_id IS NOT NULL)
+              AND i.status = 'approved'
+            ORDER BY l.name
+            """,
+            (subject_id, section),
+        )
+        rows = await cur.fetchall()
+
+    return [{"id": _id, "tag": name, "display": name} for _id, name in rows]
+
 async def get_years(
     subject_id: int, section: str, only_approved: bool = True
 ) -> list[int]:

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -10,7 +10,7 @@ from bot.db import (
     get_subjects_by_level_and_term,
     term_feature_flags,
     get_available_sections_for_subject,
-    get_lecturers_for_subject_section,
+    get_lecturers,
     has_lecture_category,
     get_years_for_subject_section_lecturer,
     list_lecture_titles,
@@ -58,7 +58,7 @@ from ..keyboards.builders import (
     generate_subject_sections_keyboard_dynamic,
     generate_lecturer_filter_keyboard,
     build_subject_section_menu,
-    generate_lecturers_keyboard,
+    build_lecturers_menu,
     generate_lecture_titles_keyboard,
     generate_year_category_menu_keyboard,
     build_years_menu,
@@ -140,7 +140,7 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if top_type == "section":
         subject_id = nav.data.get("subject_id")
         section_code = nav.data.get("section")
-        lecturers = await get_lecturers_for_subject_section(subject_id, section_code)
+        lecturers = await get_lecturers(subject_id, section_code)
         has_syllabus = bool(
             await get_materials_by_category(subject_id, section_code, "syllabus")
         )
@@ -204,8 +204,14 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if top_type == "lecturer_list":
         subject_id = nav.data.get("subject_id")
         section_code = nav.data.get("section")
-        lecturers = await get_lecturers_for_subject_section(subject_id, section_code)
-        return await update.message.reply_text("اختر المحاضر:", reply_markup=generate_lecturers_keyboard(lecturers))
+        lecturers = await get_lecturers(subject_id, section_code)
+        nav.data["lecturers_map"] = {
+            to_display_name(l.get("display") or l.get("tag", "")): l["id"]
+            for l in lecturers
+        }
+        return await update.message.reply_text(
+            "اختر المحاضر:", reply_markup=build_lecturers_menu(lecturers)
+        )
 
     if top_type == "lecture_list":
         subject_id = nav.data.get("subject_id")
@@ -417,7 +423,7 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         nav.set_section(text, section_code)
 
         subject_id = nav.data.get("subject_id")
-        lecturers = await get_lecturers_for_subject_section(subject_id, section_code)
+        lecturers = await get_lecturers(subject_id, section_code)
         has_syllabus = bool(
             await get_materials_by_category(subject_id, section_code, "syllabus")
         )
@@ -457,17 +463,20 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             )
 
         if text == FILTER_BY_LECTURER:
-            lecturers = await get_lecturers_for_subject_section(subject_id, section_code)
+            lecturers = await get_lecturers(subject_id, section_code)
             if not lecturers:
                 return await update.message.reply_text(
                     "لا يوجد محاضرون مرتبطون بهذا القسم.",
                     reply_markup=generate_subject_sections_keyboard_dynamic([]),
                 )
-            lect_map = {to_display_name(name): _id for _id, name in lecturers}
+            lect_map = {
+                to_display_name(l.get("display") or l.get("tag", "")): l["id"]
+                for l in lecturers
+            }
             nav.data["lecturers_map"] = lect_map
             nav.push_view("lecturer_list")
             return await update.message.reply_text(
-                "اختر المحاضر:", reply_markup=generate_lecturers_keyboard(lecturers)
+                "اختر المحاضر:", reply_markup=build_lecturers_menu(lecturers)
             )
 
         if text == LIST_LECTURES:

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -305,6 +305,23 @@ def build_lectures_menu(lectures: list[dict]) -> ReplyKeyboardMarkup:
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
+def build_lecturers_menu(lecturers: list[dict]) -> ReplyKeyboardMarkup:
+    """Build a keyboard listing lecturers by name.
+
+    ``lecturers`` should contain dictionaries with ``id``, ``tag`` and
+    ``display`` keys. The ``display`` value is normalized with
+    :func:`to_display_name` before being used as a button label.
+    """
+
+    labels = [to_display_name(l.get("display") or l.get("tag", "")) for l in lecturers]
+    keyboard = _rows(labels, cols=2)
+    if keyboard:
+        keyboard.append([BACK])
+    else:
+        keyboard = [[BACK]]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
 def build_types_menu(types: dict[str, dict]) -> ReplyKeyboardMarkup:
     """Build menu for available content types.
 
@@ -361,6 +378,7 @@ __all__ = [
     "build_year_root_menu",
     "build_years_menu",
     "build_lectures_menu",
+    "build_lecturers_menu",
     "build_types_menu",
     "build_exams_menu",
 ]


### PR DESCRIPTION
## Summary
- add DB helper to fetch lecturers with approved materials for a subject section
- show lecturers menu via new keyboard builder and to_display_name formatting
- wire up navigation to use the new helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc3b5a5ec83299d1173446862ef9a